### PR TITLE
perf: remove seemingly unnecessary check

### DIFF
--- a/zi_lib/zi/mesh/tri_mesh.hpp
+++ b/zi_lib/zi/mesh/tri_mesh.hpp
@@ -302,11 +302,6 @@ public:
         ZI_ASSERT( x < size_ && y < size_ && z < size_ );
 
         ++max_face_;
-        while ( faces_.count( max_face_ ) )
-        {
-            ++max_face_;
-        }
-
         faces_.insert( std::make_pair( max_face_, face_type( x, y, z ) ) );
 
         add_edge( x, y, z, max_face_ );


### PR DESCRIPTION
Removing this apparently unnecessary logic saves a frequently called `unordered_map` access. In tests, this could drop several seconds from a 52 second run.