### PR TITLE
perf: exploit accumulation of bits to avoid last round

### DIFF
--- a/zi_lib/zi/mesh/marching_cubes.hpp
+++ b/zi_lib/zi/mesh/marching_cubes.hpp
@@ -342,28 +342,10 @@ private:
                 std::array<LabelType, 8> ulabels = labels;
                 zi::mesh::sort_8(ulabels);
 
-                for (int i = 7; i >= 0; i--)
-                {
-                    const LabelType label = ulabels[i];
-                    if (label == 0)
-                    {
-                        break;
-                    }
-                    else if (i < 7 && ulabels[i + 1] == label)
-                    {
-                        continue;
-                    }
-
-                    std::size_t c = 0;
-
-                    for (std::size_t n = 0; n < 8; ++n)
-                    {
-                        c |= (labels[n] != label) << n;
-                    }
-
+                auto add_face = [&](const LabelType label, const uint8_t c) {
                     if (!mc_edge_table[c])
                     {
-                        continue;
+                        return;
                     }
 
                     PositionType cur =
@@ -382,6 +364,50 @@ private:
                             edge_midpoints[mc_triangle_table[c][n + 2]] + cur,
                             edge_midpoints[mc_triangle_table[c][n + 1]] + cur,
                             edge_midpoints[mc_triangle_table[c][n]] + cur);
+                    }
+                };
+
+                // i=7
+                uint8_t accumulate = 0;
+                uint8_t c;
+
+                LabelType label = ulabels[7];
+                if (label == 0)
+                {
+                    return;
+                }
+
+                c = 0;
+                for (int n = 0; n < 8; n++) {
+                    c |= (uint8_t)(labels[n] != label) << n;
+                }
+                accumulate |= (uint8_t)~c;
+                add_face(label, c);
+
+                for (int i = 6; i >= 0 && accumulate != 0xff; i--)
+                {
+                    label = ulabels[i];
+                    if (label == 0)
+                    {
+                        break;
+                    }
+                    else if (ulabels[i + 1] == label)
+                    {
+                        continue;
+                    }
+
+                    if (label == ulabels[0]) {
+                        c = accumulate;
+                        add_face(label, c);
+                        break;
+                    }
+                    else {
+                        c = 0;
+                        for (int n = 0; n < 8; n++) {
+                            c |= (uint8_t)(labels[n] != label) << n;
+                        }
+                        accumulate |= (uint8_t)~c;
+                        add_face(label, c);
                     }
                 }
             },


### PR DESCRIPTION
Uses two tricks:

1) accumulate `c` into a second bitfield progressively so that we can avoid recomputing c on the last iteration
2) detects the last iteration by checking accumulate for 0xff and for matching the final label

NEW:

ZMESH
marching cubes (blank): 0.298s, 450.09 MVx/sec, N=1
marching cubes (filled): 0.329s, 407.40 MVx/sec, N=1
marching cubes (connectomics.npy): 4.127s, 97.40 MVx/sec, N=3
marching cubes (random): 6.802s, 13.08 MVx/sec, N=1

OLD:

ZMESH
marching cubes (blank): 0.440s, 304.34 MVx/sec, N=1
marching cubes (filled): 0.401s, 333.88 MVx/sec, N=1
marching cubes (connectomics.npy): 4.488s, 89.56 MVx/sec, N=3
marching cubes (random): 9.136s, 9.74 MVx/sec, N=1
