### PR TITLE
perf: additional marching cubes speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ mesher = Mesher( (4,4,40) ) # anisotropy of image
 # initial marching cubes pass
 # close controls whether meshes touching
 # the image boundary are left open or closed
-mesher.mesh(labels, close=False) 
+mesher.mesh(labels, close=False)
+
+# If you don't mind shuffling the vertices and faces
+# from older versions of zmesh, this option unlocks
+# some performance optimizations.
+mesher.mesh(labels, preserve_order=False) 
 
 meshes = []
 for obj_id in mesher.ids():

--- a/perf.py
+++ b/perf.py
@@ -23,13 +23,13 @@ def result(label, dt, data, N):
     mvx = voxels // (10 ** 6)
     print(f"{label}: {dt:02.3f}s, {N * mvx / dt:.2f} MVx/sec, N={N}")
 
-def test_zmesh_marching_cubes():
+def test_zmesh_marching_cubes(preserve_order=False):
     labels = np.zeros((512,512,512), dtype=np.uint8, order="C")
     mesher = zmesh.Mesher((1,1,1))
     N = 1
     start = time.time()
     for _ in range(N):
-        mesher.mesh(labels)
+        mesher.mesh(labels, preserve_order=preserve_order)
     end = time.time()
     result("marching cubes (blank)", end - start, labels, N=N)
 
@@ -38,7 +38,7 @@ def test_zmesh_marching_cubes():
     N = 1
     start = time.time()
     for _ in range(N):
-        mesher.mesh(labels, close=True)
+        mesher.mesh(labels, close=True, preserve_order=preserve_order)
     end = time.time()
     result("marching cubes (filled)", end - start, labels, N=N)
 
@@ -46,10 +46,10 @@ def test_zmesh_marching_cubes():
     labels = np.ascontiguousarray(labels)
     mesher = zmesh.Mesher((1,1,1))
 
-    N = 1
+    N = 3
     start = time.time()
     for _ in range(N):
-        mesher.mesh(labels)
+        mesher.mesh(labels, preserve_order=preserve_order)
     end = time.time()
     result("marching cubes (connectomics.npy)", end - start, labels, N=N)
 
@@ -60,7 +60,7 @@ def test_zmesh_marching_cubes():
     N = 1
     start = time.time()
     for _ in range(N):
-        mesher.mesh(labels)
+        mesher.mesh(labels, preserve_order=preserve_order)
     end = time.time()
     result("marching cubes (random)", end - start, labels, N=N)
 

--- a/perf.py
+++ b/perf.py
@@ -105,11 +105,10 @@ def test_zmesh_simplification():
     N = 1
     start = time.time()
     for label in tqdm(mesher.ids()):
-        mesher.get_mesh(label, 
-            simplification_factor=100, 
-
+        mesher.get(label, 
+            reduction_factor=100, 
             # Max tolerable error in physical distance
-            max_simplification_error=1,
+            max_error=1,
         )
     end = time.time()
     result("simplification (connectomics.npy)", end - start, labels, N=N)

--- a/templates/mesherclass.j2
+++ b/templates/mesherclass.j2
@@ -7,11 +7,12 @@ cdef class Mesher{{ position_type }}{{ '%02d' % label_type }}:
   def __dealloc__(self):
     del self.ptr
 
-  def mesh(self, data):
+  def mesh(self, data, preserve_order:bool):
     cdef cnp.ndarray[uint{{label_type}}_t, ndim=1] flat_data = reshape(data, (data.size,)).view(np.uint{{ label_type }})
     self.ptr.mesh(
       &flat_data[0],
       data.shape[0], data.shape[1], data.shape[2],
+      preserve_order,
       data.flags.c_contiguous
     )
 

--- a/zi_lib/zi/mesh/int_mesh.hpp
+++ b/zi_lib/zi/mesh/int_mesh.hpp
@@ -19,6 +19,7 @@
 #ifndef ZI_MESH_INT_MESH_HPP
 #define ZI_MESH_INT_MESH_HPP 1
 
+#include <deque>
 #include <vector>
 #include <zi/mesh/marching_cubes.hpp>
 #include <zi/mesh/quadratic_simplifier.hpp>
@@ -53,6 +54,15 @@ public:
     void clear()
     {
         v_.clear();
+    }
+
+    void add(const std::deque< triangle_t >& v, PositionType x=0, PositionType y=0, PositionType z=0)
+    {
+        PositionType off = static_cast<PositionType>(marcher_t::pack_coords(x*2,y*2,z*2));
+        for ( std::size_t i = 0; i < v.size(); ++i )
+        {
+            v_.push_back(v[i] + off);
+        }
     }
 
     void add(const std::vector< triangle_t >& v, PositionType x=0, PositionType y=0, PositionType z=0)

--- a/zi_lib/zi/mesh/marching_cubes.hpp
+++ b/zi_lib/zi/mesh/marching_cubes.hpp
@@ -420,7 +420,6 @@ private:
                 order_tag);
         }
         else {
-            printf("HERE\n");
             mc_nested_loops(
                 sx, sy, sz,
                 [&](std::size_t x, std::size_t y, std::size_t z, std::size_t ind)

--- a/zi_lib/zi/mesh/marching_cubes.hpp
+++ b/zi_lib/zi/mesh/marching_cubes.hpp
@@ -285,11 +285,13 @@ private:
     }
 
     template <class Tag>
-    void marche(const LabelType* data, std::size_t const sx,
-                std::size_t const sy, std::size_t const sz,
-                const bool preserve_order,
-                Tag const& order_tag)
-    {
+    [[gnu::flatten]] // needed to get add_face lambda to inline properly
+    void marche(
+        const LabelType* data,
+        std::size_t const sx, std::size_t const sy, std::size_t const sz,
+        const bool preserve_order,
+        Tag const& order_tag
+    ) {
         meshes_.reserve(sx * sy);
 
         constexpr std::array<PositionType, 8> cube_corners = {

--- a/zi_lib/zi/mesh/marching_cubes.hpp
+++ b/zi_lib/zi/mesh/marching_cubes.hpp
@@ -359,14 +359,21 @@ private:
                 uint8_t c = 0;
 
                 for (int i = 0, j = 0; i < 8 && accumulate != 0xff; i++) {
-                    int start = __builtin_ffs(~accumulate);
-                    start = start > 0 ? start - 1 : 0;
+                    int start = __builtin_ctz(~accumulate);
+                    int end = 8 - ((__builtin_clz((uint8_t)~accumulate)) - 24);
 
                     const LabelType label = labels[start];
 
                     c = 0;
-                    for (int n = start; n < 8; n++) {
-                        c |= (uint8_t)(labels[n] != label) << n;
+                    if (end == 8) {
+                        for (int n = start; n < 8; n++) {
+                            c |= (uint8_t)(labels[n] != label) << n;
+                        }
+                    }
+                    else {
+                        for (int n = start; n < end; n++) {
+                            c |= (uint8_t)(labels[n] != label) << n;
+                        }
                     }
                     accumulate |= (uint8_t)~c;
 

--- a/zi_lib/zi/mesh/marching_cubes.hpp
+++ b/zi_lib/zi/mesh/marching_cubes.hpp
@@ -27,6 +27,7 @@
 #include "detail/mc_tables.hpp"
 
 #include <zi/mesh/network_sort.hpp>
+#include <zi/utility/builtins.hpp>
 #include <zi/vl/vec.hpp>
 
 #include <algorithm>
@@ -37,8 +38,6 @@
 #include <type_traits>
 #include <unordered_map>
 #include <vector>
-
-#include "builtins.hpp"
 
 namespace zi::mesh
 {
@@ -163,7 +162,7 @@ public:
     using triangle_t = vl::vec<PositionType, 3>;
 
     std::size_t                                            num_faces_;
-    std::unordered_map<LabelType, std::vector<triangle_t>> meshes_;
+    std::unordered_map<LabelType, std::deque<triangle_t>> meshes_;
 
 public:
     const auto& meshes() const
@@ -402,7 +401,7 @@ public:
         }
     }
 
-    std::vector<triangle_t> const& get_triangles(LabelType const& id) const
+    auto const& get_triangles(LabelType const& id) const
     {
         return meshes_.find(id)->second;
     }

--- a/zi_lib/zi/mesh/marching_cubes.hpp
+++ b/zi_lib/zi/mesh/marching_cubes.hpp
@@ -358,7 +358,7 @@ private:
                 uint8_t accumulate = 0;
                 uint8_t c = 0;
 
-                for (int i = 0, j = 0; i < 8 && accumulate != 0xff; i++) {
+                for (int i = 0; i < 8 && accumulate != 0xff; i++) {
                     int start = __builtin_ctz(~accumulate);
                     int end = 8 - ((__builtin_clz((uint8_t)~accumulate)) - 24);
 

--- a/zi_lib/zi/mesh/marching_cubes.hpp
+++ b/zi_lib/zi/mesh/marching_cubes.hpp
@@ -391,7 +391,7 @@ private:
                     c |= (uint8_t)(labels[n] != label) << n;
                 }
                 accumulate |= (uint8_t)~c;
-                add_face(x,y,z,label, c);
+                add_face(x, y, z, label, c);
 
                 for (int i = 6; i >= 0 && accumulate != 0xff; i--) {
                     label = ulabels[i];
@@ -404,7 +404,7 @@ private:
 
                     if (label == ulabels[0]) {
                         c = accumulate;
-                        add_face(x,y,z,label, c);
+                        add_face(x, y, z, label, c);
                         break;
                     }
                     else {
@@ -413,7 +413,7 @@ private:
                             c |= (uint8_t)(labels[n] != label) << n;
                         }
                         accumulate |= (uint8_t)~c;
-                        add_face(x,y,z,label, c);
+                        add_face(x, y, z, label, c);
                     }
                 }
             },
@@ -461,7 +461,7 @@ private:
                     accumulate |= (uint8_t)~c;
 
                     if (label != 0) {
-                        add_face(x,y,z,label, c);
+                        add_face(x, y, z, label, c);
                     }
                 }
             },

--- a/zi_lib/zi/mesh/marching_cubes.hpp
+++ b/zi_lib/zi/mesh/marching_cubes.hpp
@@ -330,18 +330,6 @@ private:
                     return;
                 }
 
-                // Instead of using std::unordered_set or similar
-                // to get unique labels, use a high efficiency sort,
-                // a "network sort", for a fixed size labels and then
-                // iterate from high to low values and skip repeats.
-                // This Saves almost 40% of the march time. We make an
-                // array copy before sorting to preserve the structure
-                // in labels. std::unordered_set uses a hash with closed
-                // addressing + chaining which is inefficient for our
-                // case.
-                std::array<LabelType, 8> ulabels = labels;
-                zi::mesh::sort_8(ulabels);
-
                 auto add_face = [&](const LabelType label, const uint8_t c) {
                     if (!mc_edge_table[c])
                     {
@@ -367,46 +355,22 @@ private:
                     }
                 };
 
-                // i=7
                 uint8_t accumulate = 0;
-                uint8_t c;
+                uint8_t c = 0;
 
-                LabelType label = ulabels[7];
-                if (label == 0)
-                {
-                    return;
-                }
+                for (int i = 0, j = 0; i < 8 && accumulate != 0xff; i++) {
+                    int start = __builtin_ffs(~accumulate);
+                    start = start > 0 ? start - 1 : 0;
 
-                c = 0;
-                for (int n = 0; n < 8; n++) {
-                    c |= (uint8_t)(labels[n] != label) << n;
-                }
-                accumulate |= (uint8_t)~c;
-                add_face(label, c);
+                    const LabelType label = labels[start];
 
-                for (int i = 6; i >= 0 && accumulate != 0xff; i--)
-                {
-                    label = ulabels[i];
-                    if (label == 0)
-                    {
-                        break;
+                    c = 0;
+                    for (int n = start; n < 8; n++) {
+                        c |= (uint8_t)(labels[n] != label) << n;
                     }
-                    else if (ulabels[i + 1] == label)
-                    {
-                        continue;
-                    }
+                    accumulate |= (uint8_t)~c;
 
-                    if (label == ulabels[0]) {
-                        c = accumulate;
-                        add_face(label, c);
-                        break;
-                    }
-                    else {
-                        c = 0;
-                        for (int n = 0; n < 8; n++) {
-                            c |= (uint8_t)(labels[n] != label) << n;
-                        }
-                        accumulate |= (uint8_t)~c;
+                    if (label != 0) {
                         add_face(label, c);
                     }
                 }

--- a/zi_lib/zi/mesh/marching_cubes.hpp
+++ b/zi_lib/zi/mesh/marching_cubes.hpp
@@ -287,6 +287,7 @@ private:
     template <class Tag>
     void marche(const LabelType* data, std::size_t const sx,
                 std::size_t const sy, std::size_t const sz,
+                const bool preserve_order,
                 Tag const& order_tag)
     {
         meshes_.reserve(sx * sy);
@@ -312,92 +313,177 @@ private:
 
         auto strides = get_strides(sx, sy, sz, order_tag);
 
-        mc_nested_loops(
-            sx, sy, sz,
-            [&](std::size_t x, std::size_t y, std::size_t z, std::size_t ind)
+        auto add_face = [&](
+            std::size_t x, std::size_t y, std::size_t z, 
+            const LabelType label, const uint8_t c
+        ) {
+            if (!mc_edge_table[c])
             {
-                std::array<LabelType, 8> const labels = {
-                    data[ind],
-                    data[ind + strides[0]],
-                    data[ind + strides[1]],
-                    data[ind + strides[2]],
-                    data[ind + strides[3]],
-                    data[ind + strides[4]],
-                    data[ind + strides[5]],
-                    data[ind + strides[6]]};
+                return;
+            }
 
-                if (all_equal(labels))
-                {
-                    return;
-                }
+            PositionType cur =
+                ((x * mask_traits::unit_x) | (y * mask_traits::unit_y) |
+                 (z * mask_traits::unit_z))
+                << 1;
 
-                auto add_face = [&](const LabelType label, const uint8_t c) {
-                    if (!mc_edge_table[c])
+            auto& face_list = meshes_[label];
+
+            for (std::size_t n = 0;
+                 mc_triangle_table[c][n] != mc_triangle_table_end;
+                 n += 3)
+            {
+                ++num_faces_;
+                face_list.emplace_back(
+                    edge_midpoints[mc_triangle_table[c][n + 2]] + cur,
+                    edge_midpoints[mc_triangle_table[c][n + 1]] + cur,
+                    edge_midpoints[mc_triangle_table[c][n]] + cur);
+            }
+        };
+
+        if (preserve_order) {
+            mc_nested_loops(
+                sx, sy, sz,
+                [&](std::size_t x, std::size_t y, std::size_t z, std::size_t ind
+            ) {
+                    std::array<LabelType, 8> const labels = {
+                        data[ind],
+                        data[ind + strides[0]],
+                        data[ind + strides[1]],
+                        data[ind + strides[2]],
+                        data[ind + strides[3]],
+                        data[ind + strides[4]],
+                        data[ind + strides[5]],
+                        data[ind + strides[6]]};
+
+                    if (all_equal(labels))
                     {
                         return;
                     }
 
-                    PositionType cur =
-                        ((x * mask_traits::unit_x) | (y * mask_traits::unit_y) |
-                         (z * mask_traits::unit_z))
-                        << 1;
+                    // Instead of using std::unordered_set or similar
+                    // to get unique labels, use a high efficiency sort,
+                    // a "network sort", for a fixed size labels and then
+                    // iterate from high to low values and skip repeats.
+                    // This Saves almost 40% of the march time. We make an
+                    // array copy before sorting to preserve the structure
+                    // in labels. std::unordered_set uses a hash with closed
+                    // addressing + chaining which is inefficient for our
+                    // case.
+                    std::array<LabelType, 8> ulabels = labels;
+                    zi::mesh::sort_8(ulabels);
 
-                    auto& face_list = meshes_[label];
+                    // i=7
+                    uint8_t accumulate = 0;
+                    uint8_t c;
 
-                    for (std::size_t n = 0;
-                         mc_triangle_table[c][n] != mc_triangle_table_end;
-                         n += 3)
+                    LabelType label = ulabels[7];
+                    if (label == 0)
                     {
-                        ++num_faces_;
-                        face_list.emplace_back(
-                            edge_midpoints[mc_triangle_table[c][n + 2]] + cur,
-                            edge_midpoints[mc_triangle_table[c][n + 1]] + cur,
-                            edge_midpoints[mc_triangle_table[c][n]] + cur);
+                        return;
                     }
-                };
-
-                uint8_t accumulate = 0;
-                uint8_t c = 0;
-
-                for (int i = 0; i < 8 && accumulate != 0xff; i++) {
-                    int start = zmesh_ctz(~accumulate);
-                    int end = 8 - ((zmesh_clz((uint8_t)~accumulate)) - 24);
-
-                    const LabelType label = labels[start];
 
                     c = 0;
-                    if (end == 8) {
-                        for (int n = start; n < 8; n++) {
-                            c |= (uint8_t)(labels[n] != label) << n;
-                        }
-                    }
-                    else {
-                        for (int n = start; n < end; n++) {
-                            c |= (uint8_t)(labels[n] != label) << n;
-                        }
+                    for (int n = 0; n < 8; n++) {
+                        c |= (uint8_t)(labels[n] != label) << n;
                     }
                     accumulate |= (uint8_t)~c;
+                    add_face(x,y,z,label, c);
 
-                    if (label != 0) {
-                        add_face(label, c);
+                    for (int i = 6; i >= 0 && accumulate != 0xff; i--)
+                    {
+                        label = ulabels[i];
+                        if (label == 0)
+                        {
+                            break;
+                        }
+                        else if (ulabels[i + 1] == label)
+                        {
+                            continue;
+                        }
+
+                        if (label == ulabels[0]) {
+                            c = accumulate;
+                            add_face(x,y,z,label, c);
+                            break;
+                        }
+                        else {
+                            c = 0;
+                            for (int n = 0; n < 8; n++) {
+                                c |= (uint8_t)(labels[n] != label) << n;
+                            }
+                            accumulate |= (uint8_t)~c;
+                            add_face(x,y,z,label, c);
+                        }
                     }
-                }
-            },
-            order_tag);
+                },
+                order_tag);
+        }
+        else {
+            printf("HERE\n");
+            mc_nested_loops(
+                sx, sy, sz,
+                [&](std::size_t x, std::size_t y, std::size_t z, std::size_t ind)
+                {
+                    std::array<LabelType, 8> const labels = {
+                        data[ind],
+                        data[ind + strides[0]],
+                        data[ind + strides[1]],
+                        data[ind + strides[2]],
+                        data[ind + strides[3]],
+                        data[ind + strides[4]],
+                        data[ind + strides[5]],
+                        data[ind + strides[6]]};
+
+                    if (all_equal(labels))
+                    {
+                        return;
+                    }
+
+                    uint8_t accumulate = 0;
+                    uint8_t c = 0;
+
+                    for (int i = 0; i < 8 && accumulate != 0xff; i++) {
+                        int start = zmesh_ctz(~accumulate);
+                        int end = 8 - ((zmesh_clz((uint8_t)~accumulate)) - 24);
+
+                        const LabelType label = labels[start];
+
+                        c = 0;
+                        if (end == 8) {
+                            for (int n = start; n < 8; n++) {
+                                c |= (uint8_t)(labels[n] != label) << n;
+                            }
+                        }
+                        else {
+                            for (int n = start; n < end; n++) {
+                                c |= (uint8_t)(labels[n] != label) << n;
+                            }
+                        }
+                        accumulate |= (uint8_t)~c;
+
+                        if (label != 0) {
+                            add_face(x,y,z,label, c);
+                        }
+                    }
+                },
+                order_tag);
+        }
     }
 
 public:
     void marche(const LabelType* data, std::size_t const sx,
                 std::size_t const sy, std::size_t const sz,
+                const bool preserve_order = true,
                 const bool c_order = true)
     {
         if (c_order)
         {
-            marche(data, sx, sy, sz, c_order_tag());
+            marche(data, sx, sy, sz, preserve_order, c_order_tag());
         }
         else
         {
-            marche(data, sx, sy, sz, fortran_order_tag());
+            marche(data, sx, sy, sz, preserve_order, fortran_order_tag());
         }
     }
 

--- a/zi_lib/zi/mesh/marching_cubes.hpp
+++ b/zi_lib/zi/mesh/marching_cubes.hpp
@@ -38,6 +38,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "builtins.hpp"
+
 namespace zi::mesh
 {
 
@@ -359,8 +361,8 @@ private:
                 uint8_t c = 0;
 
                 for (int i = 0; i < 8 && accumulate != 0xff; i++) {
-                    int start = __builtin_ctz(~accumulate);
-                    int end = 8 - ((__builtin_clz((uint8_t)~accumulate)) - 24);
+                    int start = zmesh_ctz(~accumulate);
+                    int end = 8 - ((zmesh_clz((uint8_t)~accumulate)) - 24);
 
                     const LabelType label = labels[start];
 

--- a/zi_lib/zi/mesh/marching_cubes.hpp
+++ b/zi_lib/zi/mesh/marching_cubes.hpp
@@ -294,12 +294,13 @@ private:
     ) {
         meshes_.reserve(sx * sy);
 
-        constexpr std::array<PositionType, 8> cube_corners = {
+        constexpr static std::array<PositionType, 8> cube_corners = {
             pack_coords(0, 0, 0), pack_coords(2, 0, 0), pack_coords(2, 0, 2),
             pack_coords(0, 0, 2), pack_coords(0, 2, 0), pack_coords(2, 2, 0),
-            pack_coords(2, 2, 2), pack_coords(0, 2, 2)};
+            pack_coords(2, 2, 2), pack_coords(0, 2, 2)
+        };
 
-        constexpr std::array<PositionType, 12> edge_midpoints = {
+        constexpr static std::array<PositionType, 12> edge_midpoints = {
             midpoint(cube_corners[0], cube_corners[1]),
             midpoint(cube_corners[1], cube_corners[2]),
             midpoint(cube_corners[2], cube_corners[3]),
@@ -311,7 +312,8 @@ private:
             midpoint(cube_corners[0], cube_corners[4]),
             midpoint(cube_corners[1], cube_corners[5]),
             midpoint(cube_corners[2], cube_corners[6]),
-            midpoint(cube_corners[3], cube_corners[7])};
+            midpoint(cube_corners[3], cube_corners[7])
+        };
 
         auto strides = get_strides(sx, sy, sz, order_tag);
 
@@ -319,8 +321,7 @@ private:
             std::size_t x, std::size_t y, std::size_t z, 
             const LabelType label, const uint8_t c
         ) {
-            if (!mc_edge_table[c])
-            {
+            if (!mc_edge_table[c]) {
                 return;
             }
 
@@ -331,10 +332,11 @@ private:
 
             auto& face_list = meshes_[label];
 
-            for (std::size_t n = 0;
-                 mc_triangle_table[c][n] != mc_triangle_table_end;
-                 n += 3)
-            {
+            for (
+                std::size_t n = 0;
+                mc_triangle_table[c][n] != mc_triangle_table_end;
+                n += 3
+            ) {
                 ++num_faces_;
                 face_list.emplace_back(
                     edge_midpoints[mc_triangle_table[c][n + 2]] + cur,
@@ -346,129 +348,124 @@ private:
         if (preserve_order) {
             mc_nested_loops(
                 sx, sy, sz,
-                [&](std::size_t x, std::size_t y, std::size_t z, std::size_t ind
-            ) {
-                    std::array<LabelType, 8> const labels = {
-                        data[ind],
-                        data[ind + strides[0]],
-                        data[ind + strides[1]],
-                        data[ind + strides[2]],
-                        data[ind + strides[3]],
-                        data[ind + strides[4]],
-                        data[ind + strides[5]],
-                        data[ind + strides[6]]};
+                [&](std::size_t x, std::size_t y, std::size_t z, std::size_t ind)
+            {
+                std::array<LabelType, 8> const labels = {
+                    data[ind],
+                    data[ind + strides[0]],
+                    data[ind + strides[1]],
+                    data[ind + strides[2]],
+                    data[ind + strides[3]],
+                    data[ind + strides[4]],
+                    data[ind + strides[5]],
+                    data[ind + strides[6]]};
 
-                    if (all_equal(labels))
-                    {
-                        return;
+                if (all_equal(labels))
+                {
+                    return;
+                }
+
+                // Instead of using std::unordered_set or similar
+                // to get unique labels, use a high efficiency sort,
+                // a "network sort", for a fixed size labels and then
+                // iterate from high to low values and skip repeats.
+                // This Saves almost 40% of the march time. We make an
+                // array copy before sorting to preserve the structure
+                // in labels. std::unordered_set uses a hash with closed
+                // addressing + chaining which is inefficient for our
+                // case.
+                std::array<LabelType, 8> ulabels = labels;
+                zi::mesh::sort_8(ulabels);
+
+                // i=7
+                uint8_t accumulate = 0;
+                uint8_t c;
+
+                LabelType label = ulabels[7];
+                if (label == 0) {
+                    return;
+                }
+
+                c = 0;
+                for (int n = 0; n < 8; n++) {
+                    c |= (uint8_t)(labels[n] != label) << n;
+                }
+                accumulate |= (uint8_t)~c;
+                add_face(x,y,z,label, c);
+
+                for (int i = 6; i >= 0 && accumulate != 0xff; i--) {
+                    label = ulabels[i];
+                    if (label == 0) {
+                        break;
+                    }
+                    else if (ulabels[i + 1] == label) {
+                        continue;
                     }
 
-                    // Instead of using std::unordered_set or similar
-                    // to get unique labels, use a high efficiency sort,
-                    // a "network sort", for a fixed size labels and then
-                    // iterate from high to low values and skip repeats.
-                    // This Saves almost 40% of the march time. We make an
-                    // array copy before sorting to preserve the structure
-                    // in labels. std::unordered_set uses a hash with closed
-                    // addressing + chaining which is inefficient for our
-                    // case.
-                    std::array<LabelType, 8> ulabels = labels;
-                    zi::mesh::sort_8(ulabels);
-
-                    // i=7
-                    uint8_t accumulate = 0;
-                    uint8_t c;
-
-                    LabelType label = ulabels[7];
-                    if (label == 0)
-                    {
-                        return;
+                    if (label == ulabels[0]) {
+                        c = accumulate;
+                        add_face(x,y,z,label, c);
+                        break;
                     }
-
-                    c = 0;
-                    for (int n = 0; n < 8; n++) {
-                        c |= (uint8_t)(labels[n] != label) << n;
+                    else {
+                        c = 0;
+                        for (int n = 0; n < 8; n++) {
+                            c |= (uint8_t)(labels[n] != label) << n;
+                        }
+                        accumulate |= (uint8_t)~c;
+                        add_face(x,y,z,label, c);
                     }
-                    accumulate |= (uint8_t)~c;
-                    add_face(x,y,z,label, c);
-
-                    for (int i = 6; i >= 0 && accumulate != 0xff; i--)
-                    {
-                        label = ulabels[i];
-                        if (label == 0)
-                        {
-                            break;
-                        }
-                        else if (ulabels[i + 1] == label)
-                        {
-                            continue;
-                        }
-
-                        if (label == ulabels[0]) {
-                            c = accumulate;
-                            add_face(x,y,z,label, c);
-                            break;
-                        }
-                        else {
-                            c = 0;
-                            for (int n = 0; n < 8; n++) {
-                                c |= (uint8_t)(labels[n] != label) << n;
-                            }
-                            accumulate |= (uint8_t)~c;
-                            add_face(x,y,z,label, c);
-                        }
-                    }
-                },
-                order_tag);
+                }
+            },
+            order_tag);
         }
         else {
             mc_nested_loops(
                 sx, sy, sz,
                 [&](std::size_t x, std::size_t y, std::size_t z, std::size_t ind)
-                {
-                    std::array<LabelType, 8> const labels = {
-                        data[ind],
-                        data[ind + strides[0]],
-                        data[ind + strides[1]],
-                        data[ind + strides[2]],
-                        data[ind + strides[3]],
-                        data[ind + strides[4]],
-                        data[ind + strides[5]],
-                        data[ind + strides[6]]};
+            {
+                std::array<LabelType, 8> const labels = {
+                    data[ind],
+                    data[ind + strides[0]],
+                    data[ind + strides[1]],
+                    data[ind + strides[2]],
+                    data[ind + strides[3]],
+                    data[ind + strides[4]],
+                    data[ind + strides[5]],
+                    data[ind + strides[6]]};
 
-                    if (all_equal(labels))
-                    {
-                        return;
-                    }
+                if (all_equal(labels)) {
+                    return;
+                }
 
-                    uint8_t accumulate = 0;
-                    uint8_t c = 0;
+                uint8_t accumulate = 0;
+                uint8_t c = 0;
 
-                    for (int i = 0; i < 8 && accumulate != 0xff; i++) {
-                        int start = zmesh_ctz(~accumulate);
-                        int end = 8 - ((zmesh_clz((uint8_t)~accumulate)) - 24);
+                for (int i = 0; i < 8 && accumulate != 0xff; i++) {
+                    int start = zmesh_ctz(~accumulate);
+                    int end = 8 - ((zmesh_clz((uint8_t)~accumulate)) - 24);
 
-                        const LabelType label = labels[start];
+                    const LabelType label = labels[start];
 
-                        c = 0;
-                        if (end == 8) {
-                            for (int n = start; n < 8; n++) {
-                                c |= (uint8_t)(labels[n] != label) << n;
-                            }
-                        }
-                        else {
-                            for (int n = start; n < end; n++) {
-                                c |= (uint8_t)(labels[n] != label) << n;
-                            }
-                        }
-                        accumulate |= (uint8_t)~c;
-
-                        if (label != 0) {
-                            add_face(x,y,z,label, c);
+                    c = 0;
+                    if (end == 8) {
+                        for (int n = start; n < 8; n++) {
+                            c |= (uint8_t)(labels[n] != label) << n;
                         }
                     }
-                },
-                order_tag);
+                    else {
+                        for (int n = start; n < end; n++) {
+                            c |= (uint8_t)(labels[n] != label) << n;
+                        }
+                    }
+                    accumulate |= (uint8_t)~c;
+
+                    if (label != 0) {
+                        add_face(x,y,z,label, c);
+                    }
+                }
+            },
+            order_tag);
         }
     }
 

--- a/zi_lib/zi/utility/builtins.hpp
+++ b/zi_lib/zi/utility/builtins.hpp
@@ -7,8 +7,8 @@
 // Source - https://stackoverflow.com/a/20468180
 // Posted by crazyjul
 // Retrieved 2026-05-12, License - CC BY-SA 3.0
-uint32_t __inline zmesh_ctz (uint32_t value) {
-    DWORD trailing_zero = 0;
+unsigned long __inline zmesh_ctz (unsigned long value) {
+    unsigned long trailing_zero = 0;
     if (_BitScanForward(&trailing_zero, value)) {
         return trailing_zero;
     }
@@ -16,8 +16,8 @@ uint32_t __inline zmesh_ctz (uint32_t value) {
         return 32; // undefined if value 0, choose 32 as a sensible choice
     }
 }
-uint32_t __inline zmesh_clz (uint32_t value) {
-    DWORD leading_zero = 0;
+unsigned long __inline zmesh_clz (unsigned long value) {
+    unsigned long leading_zero = 0;
 
     if (_BitScanReverse(&leading_zero, value)) {
        return 31 - leading_zero;

--- a/zi_lib/zi/utility/builtins.hpp
+++ b/zi_lib/zi/utility/builtins.hpp
@@ -1,0 +1,75 @@
+#ifndef _ZMESH_BUILTINS_HXX_
+#define _ZMESH_BUILTINS_HXX_
+
+#ifdef _MSC_VER
+#  include <intrin.h>
+#  define zmesh_popcount __popcnt
+// Source - https://stackoverflow.com/a/20468180
+// Posted by crazyjul
+// Retrieved 2026-05-12, License - CC BY-SA 3.0
+uint32_t __inline zmesh_ctz (uint32_t value) {
+    DWORD trailing_zero = 0;
+    if (_BitScanForward(&trailing_zero, value)) {
+        return trailing_zero;
+    }
+    else {
+        return 32; // undefined if value 0, choose 32 as a sensible choice
+    }
+}
+uint32_t __inline zmesh_clz (uint32_t value) {
+    DWORD leading_zero = 0;
+
+    if (_BitScanReverse(&leading_zero, value)) {
+       return 31 - leading_zero;
+    }
+    else {
+         return 32; // undefined if value 0, choose 32 as a sensible choice
+    }
+}
+#else
+#  define zmesh_popcount __builtin_popcount
+#  define zmesh_ctz __builtin_ctz
+#  define zmesh_clz __builtin_clz
+#endif
+
+// Windows implementation of getline thanks to claude.ai
+#ifdef _WIN32
+#include <cstdio>
+#define SSIZE_MAX ((int64_t)(SIZE_MAX / 2))
+static int64_t getline(char** __restrict lineptr, size_t* __restrict n, FILE* __restrict stream) {
+    if (lineptr == NULL || n == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (*lineptr == NULL || *n == 0) {
+        *n = 128;
+        *lineptr = (char*)malloc(*n);
+        if (!*lineptr) return -1;
+    }
+
+    int64_t pos = 0;
+    int c;
+
+    while ((c = fgetc(stream)) != EOF) {
+        if (pos + 1 >= *n) {
+            if (*n > SSIZE_MAX / 2) {
+                errno = EOVERFLOW;
+                return -1;
+            }
+            *n *= 2;
+            char* tmp = (char*)realloc(*lineptr, *n);
+            if (!tmp) return -1;
+            *lineptr = tmp;
+        }
+        (*lineptr)[pos++] = c;
+        if (c == '\n') break;
+    }
+
+    if (pos == 0) return -1;
+    (*lineptr)[pos] = '\0';
+    return (int64_t)pos;
+}
+#endif
+
+#endif

--- a/zmesh/_zmesh.pyx
+++ b/zmesh/_zmesh.pyx
@@ -463,6 +463,9 @@ class Mesher:
       the image will be left open on the sides that touch
       the boundary. If True, this ensures that all meshes
       produced will be closed.
+    preserve_order: Allow additional performance optimizations by relaxing
+      the order labels must be processed in. A different vertex/face
+      ordering may result.
     """
     del self._mesher
 

--- a/zmesh/_zmesh.pyx
+++ b/zmesh/_zmesh.pyx
@@ -79,7 +79,12 @@ cdef extern from "cMesher.hpp" namespace "zmesh":
       unsigned int sx, 
       unsigned int sy, 
       unsigned int sz, 
-      bool c_order
+      # for backwards compatibility 
+      # preserve final vertex/face order
+      # set false for additional performance
+      # but possibly a different mesh binary
+      bool preserve_order, 
+      bool c_order # this is the input array order, C or F
     ) nogil
     vector[L] ids() nogil
     MeshObject get_mesh(
@@ -448,7 +453,7 @@ class Mesher:
     self._voxel_res = np.array(res, dtype=np.float32)
 
   @cython.binding(True)
-  def mesh(self, data, close=False):
+  def mesh(self, data:np.ndarray, close:bool = False, preserve_order:bool = True):
     """
     Triggers the multi-label meshing process.
     After the mesher has run, you can call mesher.get.
@@ -495,7 +500,7 @@ class Mesher:
 
     self._mesher = MesherClass(self.voxel_res)
 
-    return self._mesher.mesh(data)
+    return self._mesher.mesh(data, preserve_order=preserve_order)
 
   @cython.binding(True)
   def ids(self):
@@ -735,11 +740,12 @@ cdef class Mesher3208:
   def __dealloc__(self):
     del self.ptr
 
-  def mesh(self, data):
+  def mesh(self, data, preserve_order:bool):
     cdef cnp.ndarray[uint8_t, ndim=1] flat_data = reshape(data, (data.size,)).view(np.uint8)
     self.ptr.mesh(
       &flat_data[0],
       data.shape[0], data.shape[1], data.shape[2],
+      preserve_order,
       data.flags.c_contiguous
     )
 
@@ -749,7 +755,7 @@ cdef class Mesher3208:
   def get_mesh(self, mesh_id, normals=False, simplification_factor=0, max_simplification_error=40, min_simplification_error=(25 * sys.float_info.epsilon), transpose=True):
     cdef MeshObject meshobj = self.ptr.get_mesh(mesh_id, normals, simplification_factor, max_simplification_error, min_simplification_error, transpose)
     return cpp_meshobj_to_mesh(meshobj)
-  
+
   def clear(self):
     self.ptr.clear()
 
@@ -765,11 +771,12 @@ cdef class Mesher3216:
   def __dealloc__(self):
     del self.ptr
 
-  def mesh(self, data):
+  def mesh(self, data, preserve_order:bool):
     cdef cnp.ndarray[uint16_t, ndim=1] flat_data = reshape(data, (data.size,)).view(np.uint16)
     self.ptr.mesh(
       &flat_data[0],
       data.shape[0], data.shape[1], data.shape[2],
+      preserve_order,
       data.flags.c_contiguous
     )
 
@@ -779,7 +786,7 @@ cdef class Mesher3216:
   def get_mesh(self, mesh_id, normals=False, simplification_factor=0, max_simplification_error=40, min_simplification_error=(25 * sys.float_info.epsilon), transpose=True):
     cdef MeshObject meshobj = self.ptr.get_mesh(mesh_id, normals, simplification_factor, max_simplification_error, min_simplification_error, transpose)
     return cpp_meshobj_to_mesh(meshobj)
-  
+
   def clear(self):
     self.ptr.clear()
 
@@ -795,11 +802,12 @@ cdef class Mesher3232:
   def __dealloc__(self):
     del self.ptr
 
-  def mesh(self, data):
+  def mesh(self, data, preserve_order:bool):
     cdef cnp.ndarray[uint32_t, ndim=1] flat_data = reshape(data, (data.size,)).view(np.uint32)
     self.ptr.mesh(
       &flat_data[0],
       data.shape[0], data.shape[1], data.shape[2],
+      preserve_order,
       data.flags.c_contiguous
     )
 
@@ -809,7 +817,7 @@ cdef class Mesher3232:
   def get_mesh(self, mesh_id, normals=False, simplification_factor=0, max_simplification_error=40, min_simplification_error=(25 * sys.float_info.epsilon), transpose=True):
     cdef MeshObject meshobj = self.ptr.get_mesh(mesh_id, normals, simplification_factor, max_simplification_error, min_simplification_error, transpose)
     return cpp_meshobj_to_mesh(meshobj)
-  
+
   def clear(self):
     self.ptr.clear()
 
@@ -825,11 +833,12 @@ cdef class Mesher3264:
   def __dealloc__(self):
     del self.ptr
 
-  def mesh(self, data):
+  def mesh(self, data, preserve_order:bool):
     cdef cnp.ndarray[uint64_t, ndim=1] flat_data = reshape(data, (data.size,)).view(np.uint64)
     self.ptr.mesh(
       &flat_data[0],
       data.shape[0], data.shape[1], data.shape[2],
+      preserve_order,
       data.flags.c_contiguous
     )
 
@@ -839,7 +848,7 @@ cdef class Mesher3264:
   def get_mesh(self, mesh_id, normals=False, simplification_factor=0, max_simplification_error=40, min_simplification_error=(25 * sys.float_info.epsilon), transpose=True):
     cdef MeshObject meshobj = self.ptr.get_mesh(mesh_id, normals, simplification_factor, max_simplification_error, min_simplification_error, transpose)
     return cpp_meshobj_to_mesh(meshobj)
-  
+
   def clear(self):
     self.ptr.clear()
 
@@ -855,11 +864,12 @@ cdef class Mesher6408:
   def __dealloc__(self):
     del self.ptr
 
-  def mesh(self, data):
+  def mesh(self, data, preserve_order:bool):
     cdef cnp.ndarray[uint8_t, ndim=1] flat_data = reshape(data, (data.size,)).view(np.uint8)
     self.ptr.mesh(
       &flat_data[0],
       data.shape[0], data.shape[1], data.shape[2],
+      preserve_order,
       data.flags.c_contiguous
     )
 
@@ -869,7 +879,7 @@ cdef class Mesher6408:
   def get_mesh(self, mesh_id, normals=False, simplification_factor=0, max_simplification_error=40, min_simplification_error=(25 * sys.float_info.epsilon), transpose=True):
     cdef MeshObject meshobj = self.ptr.get_mesh(mesh_id, normals, simplification_factor, max_simplification_error, min_simplification_error, transpose)
     return cpp_meshobj_to_mesh(meshobj)
-  
+
   def clear(self):
     self.ptr.clear()
 
@@ -885,11 +895,12 @@ cdef class Mesher6416:
   def __dealloc__(self):
     del self.ptr
 
-  def mesh(self, data):
+  def mesh(self, data, preserve_order:bool):
     cdef cnp.ndarray[uint16_t, ndim=1] flat_data = reshape(data, (data.size,)).view(np.uint16)
     self.ptr.mesh(
       &flat_data[0],
       data.shape[0], data.shape[1], data.shape[2],
+      preserve_order,
       data.flags.c_contiguous
     )
 
@@ -899,7 +910,7 @@ cdef class Mesher6416:
   def get_mesh(self, mesh_id, normals=False, simplification_factor=0, max_simplification_error=40, min_simplification_error=(25 * sys.float_info.epsilon), transpose=True):
     cdef MeshObject meshobj = self.ptr.get_mesh(mesh_id, normals, simplification_factor, max_simplification_error, min_simplification_error, transpose)
     return cpp_meshobj_to_mesh(meshobj)
-  
+
   def clear(self):
     self.ptr.clear()
 
@@ -915,11 +926,12 @@ cdef class Mesher6432:
   def __dealloc__(self):
     del self.ptr
 
-  def mesh(self, data):
+  def mesh(self, data, preserve_order:bool):
     cdef cnp.ndarray[uint32_t, ndim=1] flat_data = reshape(data, (data.size,)).view(np.uint32)
     self.ptr.mesh(
       &flat_data[0],
       data.shape[0], data.shape[1], data.shape[2],
+      preserve_order,
       data.flags.c_contiguous
     )
 
@@ -929,7 +941,7 @@ cdef class Mesher6432:
   def get_mesh(self, mesh_id, normals=False, simplification_factor=0, max_simplification_error=40, min_simplification_error=(25 * sys.float_info.epsilon), transpose=True):
     cdef MeshObject meshobj = self.ptr.get_mesh(mesh_id, normals, simplification_factor, max_simplification_error, min_simplification_error, transpose)
     return cpp_meshobj_to_mesh(meshobj)
-  
+
   def clear(self):
     self.ptr.clear()
 
@@ -945,11 +957,12 @@ cdef class Mesher6464:
   def __dealloc__(self):
     del self.ptr
 
-  def mesh(self, data):
+  def mesh(self, data, preserve_order:bool):
     cdef cnp.ndarray[uint64_t, ndim=1] flat_data = reshape(data, (data.size,)).view(np.uint64)
     self.ptr.mesh(
       &flat_data[0],
       data.shape[0], data.shape[1], data.shape[2],
+      preserve_order,
       data.flags.c_contiguous
     )
 
@@ -959,7 +972,7 @@ cdef class Mesher6464:
   def get_mesh(self, mesh_id, normals=False, simplification_factor=0, max_simplification_error=40, min_simplification_error=(25 * sys.float_info.epsilon), transpose=True):
     cdef MeshObject meshobj = self.ptr.get_mesh(mesh_id, normals, simplification_factor, max_simplification_error, min_simplification_error, transpose)
     return cpp_meshobj_to_mesh(meshobj)
-  
+
   def clear(self):
     self.ptr.clear()
 

--- a/zmesh/builtins.hpp
+++ b/zmesh/builtins.hpp
@@ -7,8 +7,8 @@
 // Source - https://stackoverflow.com/a/20468180
 // Posted by crazyjul
 // Retrieved 2026-05-12, License - CC BY-SA 3.0
-uint32_t __inline zmesh_ctz (uint32_t value) {
-    DWORD trailing_zero = 0;
+unsigned long __inline zmesh_ctz (unsigned long value) {
+    unsigned long trailing_zero = 0;
     if (_BitScanForward(&trailing_zero, value)) {
         return trailing_zero;
     }
@@ -16,8 +16,8 @@ uint32_t __inline zmesh_ctz (uint32_t value) {
         return 32; // undefined if value 0, choose 32 as a sensible choice
     }
 }
-uint32_t __inline zmesh_clz (uint32_t value) {
-    DWORD leading_zero = 0;
+unsigned long __inline zmesh_clz (unsigned long value) {
+    unsigned long leading_zero = 0;
 
     if (_BitScanReverse(&leading_zero, value)) {
        return 31 - leading_zero;

--- a/zmesh/builtins.hpp
+++ b/zmesh/builtins.hpp
@@ -1,50 +1,36 @@
 #ifndef _ZMESH_BUILTINS_HXX_
 #define _ZMESH_BUILTINS_HXX_
 
-
 #ifdef _MSC_VER
 #  include <intrin.h>
-#  define popcount __popcnt
-
-// https://stackoverflow.com/questions/355967/how-to-use-msvc-intrinsics-to-get-the-equivalent-of-this-gcc-code
-unsigned long ctz(unsigned long value) {
-    unsigned long trailing_zero = 0;
+#  define zmesh_popcount __popcnt
+// Source - https://stackoverflow.com/a/20468180
+// Posted by crazyjul
+// Retrieved 2026-05-12, License - CC BY-SA 3.0
+uint32_t __inline zmesh_ctz (uint32_t value) {
+    DWORD trailing_zero = 0;
     if (_BitScanForward(&trailing_zero, value)) {
         return trailing_zero;
     }
     else {
-        return 32;
+        return 32; // undefined if value 0, choose 32 as a sensible choice
+    }
+}
+uint32_t __inline zmesh_clz (uint32_t value) {
+    DWORD leading_zero = 0;
+
+    if (_BitScanReverse(&leading_zero, value)) {
+       return 31 - leading_zero;
+    }
+    else {
+         return 32; // undefined if value 0, choose 32 as a sensible choice
     }
 }
 #else
-#  define popcount __builtin_popcount
-#  define ctz __builtin_ctz
+#  define zmesh_popcount __builtin_popcount
+#  define zmesh_ctz __builtin_ctz
+#  define zmesh_clz __builtin_clz
 #endif
-
-uint32_t ffs (uint32_t x) {
-#if __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4)
-   return __builtin_ffs(x);
-#elif defined _MSC_VER
-  /* _BitScanForward
-     <https://docs.microsoft.com/en-us/cpp/intrinsics/bitscanforward-bitscanforward64> */
-  unsigned long bit;
-  if (_BitScanForward (&bit, x)) {
-    return bit + 1;
-  }
-  return 0;
-#else 
-  if (x == 0) {
-    return 0;
-  }
-  constexpr uint32_t num_bits = sizeof(x) * 8;
-  for (uint32_t i = 0; i < num_bits; i++) {
-    if ((x >> i) & 0x1) {
-        return i + 1;
-    }
-  }
-  return 0;
-#endif
-}
 
 // Windows implementation of getline thanks to claude.ai
 #ifdef _WIN32

--- a/zmesh/cMesher.hpp
+++ b/zmesh/cMesher.hpp
@@ -29,10 +29,11 @@ class CMesher {
   void mesh(
       const LabelType* data, 
       const size_t sx, const size_t sy, const size_t sz,
+      const bool preserve_order = true,
       const bool c_order = true
     ) {
     // Run global marching cubes, a mesh is generated for each segment ID group
-    marchingcubes_.marche(data, sx, sy, sz, c_order);
+    marchingcubes_.marche(data, sx, sy, sz, preserve_order, c_order);
   }
 
   std::vector<LabelType> ids() {

--- a/zmesh/cMesher.hpp
+++ b/zmesh/cMesher.hpp
@@ -1,6 +1,7 @@
 #ifndef CMESHER_H
 #define CMESHER_H
 
+#include <deque>
 #include <vector>
 #include <zi/mesh/marching_cubes.hpp>
 #include <zi/mesh/int_mesh.hpp>
@@ -64,7 +65,7 @@ class CMesher {
       return empty_obj;
     }
 
-    std::vector< zi::vl::vec< PositionType, 3> > triangles = std::move(marchingcubes_.get_triangles(segid));
+    std::deque< zi::vl::vec< PositionType, 3> > triangles = std::move(marchingcubes_.get_triangles(segid));
 
     // faster
     if (simplification_factor == 0 && !generate_normals) {
@@ -85,7 +86,7 @@ class CMesher {
   // into a vertex and face triangle soup object
   // with no simplification or normal calculation.
   zmesh::utility::MeshObject triangles2mesh(
-    const std::vector< zi::vl::vec< PositionType, 3> >& triangles,
+    const std::deque< zi::vl::vec< PositionType, 3> >& triangles,
     const bool transpose
   ) {
     zmesh::utility::MeshObject obj;
@@ -157,7 +158,7 @@ class CMesher {
   }
 
   zmesh::utility::MeshObject simplify(      
-      const std::vector< zi::vl::vec< PositionType, 3> >& triangles,
+      const std::deque< zi::vl::vec< PositionType, 3> >& triangles,
       bool generate_normals,
       int simplification_factor,
       float max_simplification_error,
@@ -265,8 +266,8 @@ class CMesher {
     float min_simplification_error
   ) {
 
-    std::vector< zi::vl::vec< PositionType, 3> > triangles;
-    triangles.reserve(Nv);
+    std::deque< zi::vl::vec< PositionType, 3> > triangles;
+    // triangles.reserve(Nv);
 
     for (size_t i = 0; i < Nv; i++) {
       triangles.push_back(


### PR DESCRIPTION
This PR introduces the `preserve_order` flag on `mesher.mesh(labels, preserve_order=False)`. This option allows the mesher to relax the ordering of vertices and faces so that the produced mesh is not necessarily bit-wise identical to older versions, but still deterministic and accurate. 

The new algorithm is significantly faster. The old algorithm will be used by default to avoid surprised.

Relaxes ordering constraint on how labels are processed.

Version 1.11.1

```
$ ./test_1_11_1 connectomics.ckl 
Time taken: 1232 ms
$ ./test_1_11_1 connectomics.ckl
Time taken: 1241 ms
$ ./test_1_11_1 connectomics.ckl
Time taken: 1250 ms
$ ./test_1_11_1 ws.ckl          
Time taken: 3442 ms
$ ./test_1_11_1 ws.ckl
Time taken: 3472 ms
$ ./test_1_11_1 ws.ckl
Time taken: 3483 ms
```
Version 1.12.0
```
$ ./test_1_12_0 connectomics.ckl 
Time taken: 1123 ms
$ ./test_1_12_0 connectomics.ckl
Time taken: 1135 ms
$ ./test_1_12_0 connectomics.ckl
Time taken: 1128 ms
$ ./test_1_12_0 ws.ckl          
Time taken: 3142 ms
$ ./test_1_12_0 ws.ckl
Time taken: 3128 ms
$ ./test_1_12_0 ws.ckl
Time taken: 3239 ms
```

This PR:
```
$ ./test_pr connectomics.ckl
Time taken: 1009 ms
$ ./test_pr connectomics.ckl
Time taken: 976 ms
$ ./test_pr connectomics.ckl
Time taken: 1007 ms
$ ./test_pr ws.ckl          
Time taken: 2877 ms
$ ./test_pr ws.ckl
Time taken: 2848 ms
$ ./test_pr ws.ckl
Time taken: 2916 ms
```
Using deque instead of vector:
```
$ ./test_pr     
Time taken: 883 ms
$ ./test_pr
Time taken: 870 ms
$ ./test_pr
Time taken: 873 ms
$ ./test_pr ws.ckl
Time taken: 2234 ms
$ ./test_pr ws.ckl
Time taken: 2279 ms
$ ./test_pr ws.ckl
Time taken: 2279 ms
```

