### PR TITLE
perf: faster simplify through improved faces access

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Compile
         run: python setup.py develop
+        env:
+          ZMESH_CHECK_ASSERTS: true
 
       - name: Test with pytest
         run: pytest -v -x automated_test.py

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,7 @@ if sys.platform == 'win32':
   ]
 else:
   extra_compile_args += [
-    '-std=c++20', '-O3', '-Wno-unused-local-typedefs', 
-    '-DNDEBUG',
+    '-std=c++20', '-O3', '-Wno-unused-local-typedefs',
   ]
 
 if sys.platform == 'darwin':
@@ -28,15 +27,24 @@ if sys.platform == 'darwin':
 
 include_dirs = [ str(NumpyImport()), 'zi_lib/', './' ]
 
+define_macros = [
+    ("NPY_NO_DEPRECATED_API", 1),
+    ("NPY_1_7_API_VERSION", 1),
+]
+
+
+def is_truthy(v):
+    return v is not None and str(v).lower() in ("1", "true", "yes", "on")
+
+check_asserts = os.environ.get("ZMESH_CHECK_ASSERTS", False)
+if not is_truthy(check_asserts):
+  define_macros.insert(0, ("NDEBUG", 1))
+
 setuptools.setup(
   setup_requires=['pbr', 'numpy', 'cython'],
   python_requires=">=3.8",
   pbr=True,
-  define_macros=[ 
-    ("NDEBUG", 1),
-    ("NPY_NO_DEPRECATED_API", 1),
-    ("NPY_1_7_API_VERSION", 1),
-  ],
+  define_macros=define_macros,
   extras_require={
     "viewer": [ "vtk" ],
   },

--- a/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
+++ b/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
@@ -53,6 +53,10 @@ private:
     }
 
 public:
+    void print() const {
+        printf("%d %d %d\n", v_[0], v_[1], v_[2]);
+    }
+
     inline bool operator==(const tri_mesh_face_impl& o) const
     {
         return std::equal(v_, v_ + 3, o.v_);

--- a/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
+++ b/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
@@ -178,7 +178,7 @@ struct trimesh_faces_iterator {
     const std::vector<face_slot>* faces;
     std::size_t idx;
 
-    tri_mesh_face_impl operator*() const { return faces->at(idx).face; }
+    tri_mesh_face_impl operator*() const { return (*faces)[idx].face; }
     trimesh_faces_iterator& operator++() {
         do { 
             ++idx; 

--- a/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
+++ b/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
@@ -235,7 +235,7 @@ public:
     {
         return faces_ |
                std::views::filter([](const face_slot& s) { return s.alive; }) |
-               std::views::transform([](const face_slot& s) -> const tri_mesh_face_impl&
+               std::views::transform([](const face_slot& s) -> const tri_mesh_face_impl
                                      { return s.face; });
     }
 

--- a/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
+++ b/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
@@ -45,7 +45,7 @@ namespace detail
 struct tri_mesh_face_impl
 {
 private:
-    uint32_t v_[3];
+    uint32_t v_[3] = {};
 
     static inline uint64_t make_edge(uint32_t x, uint32_t y)
     {
@@ -164,7 +164,7 @@ struct face_slot
     bool      alive;
 
     face_slot()
-        : alive(false)
+        : face(), alive(false)
     {
     }
     face_slot(const tri_mesh_face_impl& face_)

--- a/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
+++ b/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
@@ -53,9 +53,7 @@ private:
     }
 
 public:
-    void print() const {
-        printf("%d %d %d\n", v_[0], v_[1], v_[2]);
-    }
+    void print() const { printf("%d %d %d\n", v_[0], v_[1], v_[2]); }
 
     inline bool operator==(const tri_mesh_face_impl& o) const
     {

--- a/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
+++ b/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
@@ -158,6 +158,101 @@ private:
     }
 };
 
+struct face_slot
+{
+    tri_mesh_face_impl face;
+    bool      alive;
+
+    face_slot()
+        : alive(false)
+    {
+    }
+    face_slot(const tri_mesh_face_impl& face_)
+        : face(face_)
+        , alive(true)
+    {
+    }
+};
+
+struct trimesh_faces
+{
+private:
+    std::vector<face_slot> faces_;
+    std::vector<uint32_t>  free_list_;
+    std::size_t            size_;
+
+public:
+    trimesh_faces() { size_ = 0; }
+
+    void reserve(const std::size_t N) { faces_.reserve(N); }
+
+    bool alive(const uint32_t id) const
+    {
+        if (id == 0 || id > faces_.size())
+        {
+            return false;
+        }
+        return faces_[id - 1].alive;
+    }
+
+    tri_mesh_face_impl get(const uint32_t id) const { return faces_[id - 1].face; }
+
+    std::size_t size() const { return size_; }
+
+    std::size_t push_back(const tri_mesh_face_impl& face)
+    {
+        size_++;
+        if (free_list_.empty())
+        {
+            faces_.push_back(face);
+            return faces_.size();
+        }
+        else
+        {
+            uint32_t id      = free_list_.back();
+            faces_[id].face  = face;
+            faces_[id].alive = true;
+            return id + 1;
+        }
+    }
+
+    void clear()
+    {
+        faces_.clear();
+        free_list_.clear();
+        size_ = 0;
+    }
+
+    void erase(const uint32_t id)
+    {
+        size_ -= static_cast<std::size_t>(faces_[id - 1].alive);
+        faces_[id - 1].alive = false;
+        auto it = std::find(free_list_.begin(), free_list_.end(), id - 1);
+        if (it != free_list_.end())
+        {
+            free_list_.erase(it);
+        }
+    }
+
+    auto iter() const
+    {
+        return faces_ |
+               std::views::filter([](const face_slot& s) { return s.alive; }) |
+               std::views::transform([](const face_slot& s) -> const tri_mesh_face_impl&
+                                     { return s.face; });
+    }
+
+    auto enumerate() const
+    {
+        return std::views::iota(std::size_t{0}, faces_.size()) |
+               std::views::filter([this](std::size_t i)
+                                  { return faces_[i].alive; }) |
+               std::views::transform(
+                   [this](std::size_t i)
+                   { return std::pair{i + 1, std::cref(faces_[i].face)}; });
+    }
+};
+
 struct tri_mesh_face_container
 {
 protected:

--- a/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
+++ b/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
@@ -210,7 +210,11 @@ public:
         return faces_[id].alive;
     }
 
-    tri_mesh_face_impl get(const uint32_t id) const { return faces_[id].face; }
+    tri_mesh_face_impl get(const uint32_t id) const { 
+        ZI_ASSERT(id < faces_.size());
+        ZI_ASSERT(faces_[id].alive);
+        return faces_[id].face;
+    }
 
     std::size_t size() const { return alive_count_; }
 

--- a/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
+++ b/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
@@ -227,11 +227,7 @@ public:
     {
         size_ -= static_cast<std::size_t>(faces_[id - 1].alive);
         faces_[id - 1].alive = false;
-        auto it = std::find(free_list_.begin(), free_list_.end(), id - 1);
-        if (it != free_list_.end())
-        {
-            free_list_.erase(it);
-        }
+        free_list_.push_back(id - 1);
     }
 
     auto iter() const

--- a/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
+++ b/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
@@ -174,6 +174,21 @@ struct face_slot
     }
 };
 
+struct trimesh_faces_iterator {
+    const std::vector<face_slot>* faces;
+    std::size_t idx;
+
+    tri_mesh_face_impl operator*() const { return faces->at(idx).face; }
+    trimesh_faces_iterator& operator++() {
+        do { 
+            ++idx; 
+        } while (idx < faces->size() && !(*faces)[idx].alive);
+        return *this;
+    }
+        
+    bool operator!=(const trimesh_faces_iterator& o) const { return idx != o.idx; }
+};
+
 struct trimesh_faces
 {
 private:
@@ -231,156 +246,18 @@ public:
         free_list_.push_back(id - 1);
     }
 
-    auto iter() const
+    trimesh_faces_iterator begin() const
     {
-        return faces_ |
-               std::views::filter([](const face_slot& s) { return s.alive; }) |
-               std::views::transform([](const face_slot& s) -> const tri_mesh_face_impl
-                                     { return s.face; });
+        auto it = trimesh_faces_iterator{&faces_, 0};
+        if (!faces_.empty() && !faces_[0].alive) {
+            ++it;
+        }
+        return it;
     }
-
-    auto enumerate() const
+    
+    trimesh_faces_iterator end() const
     {
-        return std::views::iota(std::size_t{0}, faces_.size()) |
-               std::views::filter([this](std::size_t i)
-                                  { return faces_[i].alive; }) |
-               std::views::transform(
-                   [this](std::size_t i)
-                   { return std::pair{i + 1, std::cref(faces_[i].face)}; });
-    }
-};
-
-struct tri_mesh_face_container
-{
-protected:
-    reference_wrapper<unordered_map<uint32_t, tri_mesh_face_impl>> faces_;
-
-    tri_mesh_face_container(unordered_map<uint32_t, tri_mesh_face_impl>& faces)
-        : faces_(faces)
-    {
-    }
-
-    friend class ::zi::mesh::tri_mesh;
-
-public:
-    template <bool IsConst>
-    struct iterator_base
-    {
-        typedef iterator_base<IsConst>                  iterator_type;
-        typedef std::ptrdiff_t                          difference_type;
-        typedef std::forward_iterator_tag               iterator_category;
-        typedef tri_mesh_face_impl                      value_type;
-        typedef typename if_<IsConst, const tri_mesh_face_impl*,
-                             tri_mesh_face_impl*>::type pointer;
-        typedef typename if_<IsConst, const tri_mesh_face_impl&,
-                             tri_mesh_face_impl&>::type reference;
-
-        inline iterator_base()
-            : i_()
-        {
-        }
-
-        inline reference operator*() const { return i_->second; }
-        inline pointer   operator->() const { return &i_->second; }
-
-        inline iterator_type& operator++()
-        {
-            ++i_;
-            return *this;
-        }
-
-        inline iterator_type operator++(int)
-        {
-            iterator_type tmp = *this;
-            ++i_;
-            return tmp;
-        }
-
-        template <bool B>
-        inline bool operator==(const iterator_base<B>& o) const
-        {
-            return i_ == o.i_;
-        }
-
-        template <bool B>
-        inline bool operator!=(const iterator_base<B>& o) const
-        {
-            return i_ != o.i_;
-        }
-
-        inline uint32_t id() const { return i_->first; }
-        inline          operator uint32_t() const { return i_->first; }
-
-        template <std::size_t Index>
-        inline uint32_t vertex(
-            typename enable_if<(Index < 3), ::zi::detail::dummy<Index>>::type =
-                0) const
-        {
-            return i_->second.template vertex<Index>();
-        }
-
-        inline uint32_t v0() const { return i_->second.v0(); }
-        inline uint32_t v1() const { return i_->second.v1(); }
-        inline uint32_t v2() const { return i_->second.v2(); }
-
-        inline uint64_t e0() const { return i_->second.e0(); }
-        inline uint64_t e1() const { return i_->second.e1(); }
-        inline uint64_t e2() const { return i_->second.e2(); }
-
-        inline uint64_t edge(std::size_t i) { return i_->second.edge(i); }
-
-        template <std::size_t Index>
-        inline uint64_t edge(
-            typename enable_if<(Index < 3), ::zi::detail::dummy<Index>>::type =
-                0) const
-        {
-            return i_->second.template edge<Index>();
-        }
-
-        inline uint64_t edge_from(uint32_t v) const
-        {
-            return i_->second.edge_from(v);
-        }
-
-        friend struct tri_mesh_face_container;
-
-    private:
-        typedef typename if_<
-            IsConst,
-            unordered_map<uint32_t, tri_mesh_face_impl>::const_iterator,
-            unordered_map<uint32_t, tri_mesh_face_impl>::iterator>::type
-            base_type;
-
-        base_type i_;
-
-        explicit iterator_base(const base_type& i)
-            : i_(i)
-        {
-        }
-    };
-
-    typedef iterator_base<false>::iterator_type iterator;
-    typedef iterator_base<true>::iterator_type  const_iterator;
-
-    inline iterator find(uint32_t id)
-    {
-        return iterator(faces_.get().find(id));
-    }
-
-    inline const_iterator find(uint32_t id) const
-    {
-        return const_iterator(faces_.get().find(id));
-    }
-
-    inline iterator       begin() { return iterator(faces_.get().begin()); }
-    inline iterator       end() { return iterator(faces_.get().end()); }
-    inline const_iterator begin() const
-    {
-        return const_iterator(faces_.get().begin());
-    }
-    inline const_iterator end() const
-    {
-        return const_iterator(faces_.get().end());
+        return {&faces_, faces_.size()};
     }
 };
 

--- a/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
+++ b/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
@@ -203,14 +203,14 @@ public:
 
     bool alive(const uint32_t id) const
     {
-        if (id == 0 || id > faces_.size())
+        if (id >= faces_.size())
         {
             return false;
         }
-        return faces_[id - 1].alive;
+        return faces_[id].alive;
     }
 
-    tri_mesh_face_impl get(const uint32_t id) const { return faces_[id - 1].face; }
+    tri_mesh_face_impl get(const uint32_t id) const { return faces_[id].face; }
 
     std::size_t size() const { return size_; }
 
@@ -220,7 +220,7 @@ public:
         if (free_list_.empty())
         {
             faces_.push_back(face);
-            return faces_.size();
+            return faces_.size() - 1;
         }
         else
         {
@@ -228,7 +228,7 @@ public:
             free_list_.pop_back();
             faces_[id].face  = face;
             faces_[id].alive = true;
-            return id + 1;
+            return id;
         }
     }
 
@@ -241,9 +241,9 @@ public:
 
     void erase(const uint32_t id)
     {
-        size_ -= static_cast<std::size_t>(faces_[id - 1].alive);
-        faces_[id - 1].alive = false;
-        free_list_.push_back(id - 1);
+        size_ -= static_cast<std::size_t>(faces_[id].alive);
+        faces_[id].alive = false;
+        free_list_.push_back(id);
     }
 
     trimesh_faces_iterator begin() const

--- a/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
+++ b/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
@@ -194,10 +194,10 @@ struct trimesh_faces
 private:
     std::vector<face_slot> faces_;
     std::vector<uint32_t>  free_list_;
-    std::size_t            size_;
+    std::size_t            alive_count_;
 
 public:
-    trimesh_faces() { size_ = 0; }
+    trimesh_faces() { alive_count_ = 0; }
 
     void reserve(const std::size_t N) { faces_.reserve(N); }
 
@@ -212,11 +212,11 @@ public:
 
     tri_mesh_face_impl get(const uint32_t id) const { return faces_[id].face; }
 
-    std::size_t size() const { return size_; }
+    std::size_t size() const { return alive_count_; }
 
     std::size_t push_back(const tri_mesh_face_impl& face)
     {
-        size_++;
+        alive_count_++;
         if (free_list_.empty())
         {
             faces_.push_back(face);
@@ -236,12 +236,12 @@ public:
     {
         faces_.clear();
         free_list_.clear();
-        size_ = 0;
+        alive_count_ = 0;
     }
 
     void erase(const uint32_t id)
     {
-        size_ -= static_cast<std::size_t>(faces_[id].alive);
+        alive_count_ -= static_cast<std::size_t>(faces_[id].alive);
         faces_[id].alive = false;
         free_list_.push_back(id);
     }

--- a/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
+++ b/zi_lib/zi/mesh/detail/tri_mesh_face.hpp
@@ -210,6 +210,7 @@ public:
         else
         {
             uint32_t id      = free_list_.back();
+            free_list_.pop_back();
             faces_[id].face  = face;
             faces_[id].alive = true;
             return id + 1;

--- a/zi_lib/zi/mesh/quadratic_simplifier.hpp
+++ b/zi_lib/zi/mesh/quadratic_simplifier.hpp
@@ -513,7 +513,7 @@ public:
         return 0;
     }
 
-    detail::tri_mesh_face_container& faces() { return mesh_.faces; }
+    detail::tri_mesh_face_container& faces() { return mesh_.get_faces(); }
 
     std::size_t stripify(std::vector<uint32_t>& vertices,
                          std::vector<uint32_t>& strip_begins,
@@ -743,11 +743,12 @@ private:
     {
         FOR_EACH(it, quadratic_) { it->clear(); }
 
-        FOR_EACH(it, mesh_.faces)
+        for (auto& face : mesh_.get_faces().iter())
         {
-            vl::vec<Float, 3>& v0 = points_[it->v0()];
-            vl::vec<Float, 3>& v1 = points_[it->v1()];
-            vl::vec<Float, 3>& v2 = points_[it->v2()];
+            // face.print();
+            vl::vec<Float, 3>& v0 = points_[face.v0()];
+            vl::vec<Float, 3>& v1 = points_[face.v1()];
+            vl::vec<Float, 3>& v2 = points_[face.v2()];
 
             vl::vec<Float, 3> a    = cross(v1 - v0, v2 - v0);
             Float             area = normalize(a);
@@ -755,10 +756,11 @@ private:
             detail::quadratic<Float> q(a[0], a[1], a[2], -dot(a, v0));
 
             q *= (area * 2.0);
+            // printf("%.2f\n", q);
 
-            quadratic_[it->v0()] += q;
-            quadratic_[it->v1()] += q;
-            quadratic_[it->v2()] += q;
+            quadratic_[face.v0()] += q;
+            quadratic_[face.v1()] += q;
+            quadratic_[face.v2()] += q;
         }
 
         // FOR_EACH( it, d_.vd_ )
@@ -774,24 +776,24 @@ private:
 
         FOR_EACH(it, normals_) { (*it) = vl::vec<Float, 3>::zero; }
 
-        FOR_EACH(it, mesh_.faces)
+        for (auto& face : mesh_.get_faces().iter())
         {
-            vl::vec<Float, 3>& v0 = points_[it->v0()];
-            vl::vec<Float, 3>& v1 = points_[it->v1()];
-            vl::vec<Float, 3>& v2 = points_[it->v2()];
+            vl::vec<Float, 3>& v0 = points_[face.v0()];
+            vl::vec<Float, 3>& v1 = points_[face.v1()];
+            vl::vec<Float, 3>& v2 = points_[face.v2()];
 
             vl::vec<Float, 3> center(v0 + v1 + v2);
             center /= 3;
 
             vl::vec<Float, 3> n(norm(cross(v1 - v0, v2 - v0)));
             // n = norm( n ); // / n_len;
-            normals_[it->v0()] += n * len(points_[it->v0()] - center);
-            normals_[it->v1()] += n * len(points_[it->v1()] - center);
-            normals_[it->v2()] += n * len(points_[it->v2()] - center);
+            normals_[face.v0()] += n * len(points_[face.v0()] - center);
+            normals_[face.v1()] += n * len(points_[face.v1()] - center);
+            normals_[face.v2()] += n * len(points_[face.v2()] - center);
 
-            ++counts[it->v0()];
-            ++counts[it->v1()];
-            ++counts[it->v2()];
+            ++counts[face.v0()];
+            ++counts[face.v1()];
+            ++counts[face.v2()];
         }
 
         for (std::size_t i = 0; i < size_; ++i)
@@ -874,21 +876,21 @@ private:
 
     void init_heap()
     {
-        FOR_EACH(it, mesh_.faces)
+        for (auto& face : mesh_.get_faces().iter())
         {
-            if (it->v0() < it->v1())
+            if (face.v0() < face.v1())
             {
-                add_to_heap(it->v0(), it->v1());
+                add_to_heap(face.v0(), face.v1());
             }
 
-            if (it->v1() < it->v2())
+            if (face.v1() < face.v2())
             {
-                add_to_heap(it->v1(), it->v2());
+                add_to_heap(face.v1(), face.v2());
             }
 
-            if (it->v2() < it->v0())
+            if (face.v2() < face.v0())
             {
-                add_to_heap(it->v2(), it->v0());
+                add_to_heap(face.v2(), face.v0());
             }
         }
     }

--- a/zi_lib/zi/mesh/quadratic_simplifier.hpp
+++ b/zi_lib/zi/mesh/quadratic_simplifier.hpp
@@ -743,7 +743,7 @@ private:
     {
         FOR_EACH(it, quadratic_) { it->clear(); }
 
-        for (auto& face : mesh_.get_faces().iter())
+        for (auto face : mesh_.get_faces())
         {
             // face.print();
             vl::vec<Float, 3>& v0 = points_[face.v0()];
@@ -776,7 +776,7 @@ private:
 
         FOR_EACH(it, normals_) { (*it) = vl::vec<Float, 3>::zero; }
 
-        for (auto& face : mesh_.get_faces().iter())
+        for (auto face : mesh_.get_faces())
         {
             vl::vec<Float, 3>& v0 = points_[face.v0()];
             vl::vec<Float, 3>& v1 = points_[face.v1()];
@@ -876,7 +876,7 @@ private:
 
     void init_heap()
     {
-        for (auto& face : mesh_.get_faces().iter())
+        for (auto face : mesh_.get_faces())
         {
             if (face.v0() < face.v1())
             {

--- a/zi_lib/zi/mesh/quadratic_simplifier.hpp
+++ b/zi_lib/zi/mesh/quadratic_simplifier.hpp
@@ -513,7 +513,7 @@ public:
         return 0;
     }
 
-    detail::tri_mesh_face_container& faces() { return mesh_.get_faces(); }
+    auto& faces() { return mesh_.get_faces(); }
 
     std::size_t stripify(std::vector<uint32_t>& vertices,
                          std::vector<uint32_t>& strip_begins,

--- a/zi_lib/zi/mesh/tri_mesh.hpp
+++ b/zi_lib/zi/mesh/tri_mesh.hpp
@@ -28,9 +28,9 @@
 #    include <zi/utility/for_each.hpp>
 #    include <zi/utility/robin_hood.hpp>
 
-#    include <ranges>
 #    include <functional>
 #    include <iostream>
+#    include <ranges>
 #    include <stdexcept>
 #    include <vector>
 
@@ -97,67 +97,73 @@ struct tri_mesh_vertex
 
 } //  namespace detail
 
-struct face_slot {
+struct face_slot
+{
     typedef detail::tri_mesh_face_impl face_type;
 
     face_type face;
-    bool alive;
+    bool      alive;
 
-    face_slot() : alive(false) {}
-    face_slot(const face_type& face_) : face(face_), alive(true) {}
+    face_slot()
+        : alive(false)
+    {
+    }
+    face_slot(const face_type& face_)
+        : face(face_)
+        , alive(true)
+    {
+    }
 };
 
-struct trimesh_faces {
+struct trimesh_faces
+{
     typedef detail::tri_mesh_face_impl face_type;
+
 private:
     std::vector<face_slot> faces_;
-public:
-    void reserve(const std::size_t N) {
-        faces_.reserve(N);
-    }
 
-    bool alive(const uint32_t id) const {
-        if (id >= faces_.size()) {
+public:
+    void reserve(const std::size_t N) { faces_.reserve(N); }
+
+    bool alive(const uint32_t id) const
+    {
+        if (id >= faces_.size())
+        {
             return false;
         }
         return faces_[id].alive;
     }
 
-    face_type get(const uint32_t id) const {
-        return faces_[id].face;
-    }
+    face_type get(const uint32_t id) const { return faces_[id].face; }
 
-    std::size_t size() const  {
-        return faces_.size();
-    }
+    std::size_t size() const { return faces_.size(); }
 
-    std::size_t push_back(const face_type& face) {
+    std::size_t push_back(const face_type& face)
+    {
         faces_.push_back(face);
         return faces_.size() - 1;
     }
 
-    void clear() {
-        faces_.clear();
+    void clear() { faces_.clear(); }
+
+    void erase(const uint32_t id) { faces_[id].alive = false; }
+
+    auto iter() const
+    {
+        return faces_ |
+               std::views::filter([](const face_slot& s) { return s.alive; }) |
+               std::views::transform([](const face_slot& s) -> const face_type&
+                                     { return s.face; });
     }
 
-    void erase(const uint32_t id) {
-        faces_[id].alive = false;
-    }
-
-    auto iter() const {
-        return faces_
-            | std::views::filter([](const face_slot& s) { return s.alive; })
-            | std::views::transform([](const face_slot& s) -> const face_type& { return s.face; });
-    }
-
-    auto enumerate() const {
-        return std::views::iota(std::size_t{0}, faces_.size())
-            | std::views::filter([this](std::size_t i) {
-                  return faces_[i].alive;
-              })
-            | std::views::transform([this](std::size_t i) {
-                  return std::pair{i, std::cref(faces_[i].face)};
-              });
+    auto enumerate() const
+    {
+        return std::views::iota(std::size_t{0}, faces_.size()) |
+               std::views::filter([this](std::size_t i)
+                                  { return faces_[i].alive; }) |
+               std::views::transform(
+                   [this](std::size_t i)
+                   { return std::pair{i, std::cref(faces_[i].face)}; });
     }
 };
 
@@ -173,13 +179,13 @@ public:
     friend struct tri_mesh_edge;
 
 private:
-    std::size_t                           size_    ;
-    std::vector  < vertex_type >          vertices_;
-    robin_hood::unordered_flat_map< uint64_t, edge_type >  edges_   ;
-    trimesh_faces                         faces_   ;
+    std::size_t                                         size_;
+    std::vector<vertex_type>                            vertices_;
+    robin_hood::unordered_flat_map<uint64_t, edge_type> edges_;
+    trimesh_faces                                       faces_;
 
 public:
-    detail::tri_mesh_edge_container       edges;
+    detail::tri_mesh_edge_container edges;
 
 private:
     void add_edge(uint32_t x, uint32_t y, uint32_t z, uint32_t f)
@@ -236,15 +242,9 @@ private:
     }
 
 public:
-    auto& get_faces()
-    {
-        return faces_;
-    }
+    auto& get_faces() { return faces_; }
 
-    const auto& get_faces() const
-    {
-        return faces_;
-    }
+    const auto& get_faces() const { return faces_; }
 
     std::vector<vertex_type>& vertices() { return vertices_; }
 
@@ -255,32 +255,30 @@ public:
     const detail::tri_mesh_edge_container& get_edges() const { return edges; }
 
     tri_mesh()
-        : size_( 0 ),
-        vertices_( 0 ),
-        edges_(),
-        faces_(),
-        edges( edges_ )
+        : size_(0)
+        , vertices_(0)
+        , edges_()
+        , faces_()
+        , edges(edges_)
     {
     }
 
-    explicit tri_mesh( std::size_t size )
-        : size_( size ),
-          vertices_( size ),
-          edges_(),
-          faces_(),
-          edges( edges_ )
+    explicit tri_mesh(std::size_t size)
+        : size_(size)
+        , vertices_(size)
+        , edges_()
+        , faces_()
+        , edges(edges_)
     {
         faces_.reserve(size);
     }
 
-    tri_mesh( const tri_mesh& o )
-        : size_( o.size_ ),
-          vertices_( o.vertices_ ),
-          edges_( o.edges_ ),
-          faces_( o.faces_ ),
-          edges( edges_ )
-    {
-    };
+    tri_mesh(const tri_mesh& o)
+        : size_(o.size_)
+        , vertices_(o.vertices_)
+        , edges_(o.edges_)
+        , faces_(o.faces_)
+        , edges(edges_) {};
 
     tri_mesh& operator=(const tri_mesh& o)
     {
@@ -289,7 +287,7 @@ public:
         edges_    = o.edges_;
         faces_    = o.faces_;
 
-        edges = detail::tri_mesh_edge_container( edges_ );
+        edges = detail::tri_mesh_edge_container(edges_);
 
         return *this;
     };
@@ -321,18 +319,18 @@ public:
 
         ZI_ASSERT(x < size_ && y < size_ && z < size_);
 
-        const uint32_t max_face = faces_.push_back(face_type( x, y, z ));
-        
-        add_edge( x, y, z, max_face );
-        add_edge( y, z, x, max_face );
-        add_edge( z, x, y, max_face );
+        const uint32_t max_face = faces_.push_back(face_type(x, y, z));
+
+        add_edge(x, y, z, max_face);
+        add_edge(y, z, x, max_face);
+        add_edge(z, x, y, max_face);
 
         return max_face;
     }
 
     void remove_face(const uint32_t id)
     {
-        ZI_ASSERT( faces_.alive( id ) );
+        ZI_ASSERT(faces_.alive(id));
 
         const face_type f = faces_.get(id);
 
@@ -370,14 +368,14 @@ public:
             return 0;
         }
 
-        const uint32_t face_id = vertices_[ id ].face_;
+        const uint32_t face_id = vertices_[id].face_;
 
-        if ( faces_.alive( face_id ) )
+        if (faces_.alive(face_id))
         {
             return 0;
         }
 
-        return faces_.get( face_id ).edge_from( face_id );
+        return faces_.get(face_id).edge_from(face_id);
     }
 
     uint32_t across_edge(const uint64_t eid) const
@@ -523,27 +521,25 @@ public:
             ZI_THROW("check_rep: extra edges present");
         }
 
-        for (const auto& [face_id, face_ref] : faces_.enumerate() )
+        for (const auto& [face_id, face_ref] : faces_.enumerate())
         {
             const auto& face = face_ref.get();
 
-            if ( !( vertices_[ face.v0() ].valid() &&
-                    vertices_[ face.v1() ].valid() &&
-                    vertices_[ face.v2() ].valid() ) )
+            if (!(vertices_[face.v0()].valid() &&
+                  vertices_[face.v1()].valid() && vertices_[face.v2()].valid()))
             {
                 ZI_THROW("check_rep: invalid vertex found");
             }
 
-            if ( ( edges_.find( face.e0() )->second ).face() != face_id ||
-                 ( edges_.find( face.e1() )->second ).face() != face_id ||
-                 ( edges_.find( face.e2() )->second ).face() != face_id )
+            if ((edges_.find(face.e0())->second).face() != face_id ||
+                (edges_.find(face.e1())->second).face() != face_id ||
+                (edges_.find(face.e2())->second).face() != face_id)
             {
                 ZI_THROW("check_rep: edge doesn't link to the correct face");
             }
 
-            if ( !( edges_.count( face.e0() ) &&
-                    edges_.count( face.e1() ) &&
-                    edges_.count( face.e2() ) ) )
+            if (!(edges_.count(face.e0()) && edges_.count(face.e1()) &&
+                  edges_.count(face.e2())))
             {
                 ZI_THROW("check_rep: face missing an edge");
             }
@@ -585,18 +581,16 @@ public:
             }
         }
 
-        for ( auto& face : faces_.iter() )
+        for (auto& face : faces_.iter())
         {
-            if ( !( vertices_[ face.v0() ].valid() &&
-                    vertices_[ face.v1() ].valid() &&
-                    vertices_[ face.v2() ].valid() ) )
+            if (!(vertices_[face.v0()].valid() &&
+                  vertices_[face.v1()].valid() && vertices_[face.v2()].valid()))
             {
                 return false;
             }
 
-            if ( !( edges_.count( face.e0() ) &&
-                    edges_.count( face.e1() ) &&
-                    edges_.count( face.e2() ) ) )
+            if (!(edges_.count(face.e0()) && edges_.count(face.e1()) &&
+                  edges_.count(face.e2())))
             {
                 return false;
             }
@@ -607,11 +601,9 @@ public:
 
     void print_faces() const
     {
-        for ( auto& face : faces_.iter() )
+        for (auto& face : faces_.iter())
         {
-            std::cout << "f: "
-                      << face.v0() << ','
-                      << face.v1() << ','
+            std::cout << "f: " << face.v0() << ',' << face.v1() << ','
                       << face.v2() << '\n';
         }
     }
@@ -626,7 +618,7 @@ public:
     {
         r.resize(faces_.size());
         std::size_t i = 0;
-        for ( auto& face : faces_.iter() )
+        for (auto& face : faces_.iter())
         {
             r[i++] = T(face.v0(), face.v1(), face.v2());
         }

--- a/zi_lib/zi/mesh/tri_mesh.hpp
+++ b/zi_lib/zi/mesh/tri_mesh.hpp
@@ -97,105 +97,6 @@ struct tri_mesh_vertex
 
 } //  namespace detail
 
-struct face_slot
-{
-    typedef detail::tri_mesh_face_impl face_type;
-
-    face_type face;
-    bool      alive;
-
-    face_slot()
-        : alive(false)
-    {
-    }
-    face_slot(const face_type& face_)
-        : face(face_)
-        , alive(true)
-    {
-    }
-};
-
-struct trimesh_faces
-{
-    typedef detail::tri_mesh_face_impl face_type;
-
-private:
-    std::vector<face_slot> faces_;
-    std::vector<uint32_t>  free_list_;
-    std::size_t            size_;
-
-public:
-    trimesh_faces() { size_ = 0; }
-
-    void reserve(const std::size_t N) { faces_.reserve(N); }
-
-    bool alive(const uint32_t id) const
-    {
-        if (id == 0 || id > faces_.size())
-        {
-            return false;
-        }
-        return faces_[id - 1].alive;
-    }
-
-    face_type get(const uint32_t id) const { return faces_[id - 1].face; }
-
-    std::size_t size() const { return size_; }
-
-    std::size_t push_back(const face_type& face)
-    {
-        size_++;
-        if (free_list_.empty())
-        {
-            faces_.push_back(face);
-            return faces_.size();
-        }
-        else
-        {
-            uint32_t id      = free_list_.back();
-            faces_[id].face  = face;
-            faces_[id].alive = true;
-            return id + 1;
-        }
-    }
-
-    void clear()
-    {
-        faces_.clear();
-        free_list_.clear();
-        size_ = 0;
-    }
-
-    void erase(const uint32_t id)
-    {
-        size_ -= static_cast<std::size_t>(faces_[id - 1].alive);
-        faces_[id - 1].alive = false;
-        auto it = std::find(free_list_.begin(), free_list_.end(), id - 1);
-        if (it != free_list_.end())
-        {
-            free_list_.erase(it);
-        }
-    }
-
-    auto iter() const
-    {
-        return faces_ |
-               std::views::filter([](const face_slot& s) { return s.alive; }) |
-               std::views::transform([](const face_slot& s) -> const face_type&
-                                     { return s.face; });
-    }
-
-    auto enumerate() const
-    {
-        return std::views::iota(std::size_t{0}, faces_.size()) |
-               std::views::filter([this](std::size_t i)
-                                  { return faces_[i].alive; }) |
-               std::views::transform(
-                   [this](std::size_t i)
-                   { return std::pair{i + 1, std::cref(faces_[i].face)}; });
-    }
-};
-
 class tri_mesh //: non_copyable
 {
 public:
@@ -211,7 +112,7 @@ private:
     std::size_t                                         size_;
     std::vector<vertex_type>                            vertices_;
     robin_hood::unordered_flat_map<uint64_t, edge_type> edges_;
-    trimesh_faces                                       faces_;
+    detail::trimesh_faces                                       faces_;
 
 public:
     detail::tri_mesh_edge_container edges;

--- a/zi_lib/zi/mesh/tri_mesh.hpp
+++ b/zi_lib/zi/mesh/tri_mesh.hpp
@@ -131,10 +131,8 @@ public:
         faces_.reserve(N);
     }
 
-    bool alive(const uint32_t id) const
-    {
-        if (id >= faces_.size())
-        {
+    bool alive(const uint32_t id) const {
+        if (id == 0 || id >= faces_.size()) {
             return false;
         }
         return faces_[id-1].alive;
@@ -152,7 +150,7 @@ public:
     {
         faces_.push_back(face);
         size_++;
-        return size_;
+        return faces_.size();
     }
 
     void clear() {
@@ -161,8 +159,8 @@ public:
     }
 
     void erase(const uint32_t id) {
-        size_ -= faces_[id].alive;
-        faces_[id].alive = false;
+        size_ -= faces_[id-1].alive;
+        faces_[id-1].alive = false;
     }
 
     auto iter() const

--- a/zi_lib/zi/mesh/tri_mesh.hpp
+++ b/zi_lib/zi/mesh/tri_mesh.hpp
@@ -310,8 +310,7 @@ public:
         size_ = s;
         vertices_.resize(s);
         edges_.clear();
-        faces_.clear();
-        max_face_ = 0;
+        faces_.clear(); 
     }
 
     uint32_t add_face(const uint32_t x, const uint32_t y, const uint32_t z)

--- a/zi_lib/zi/mesh/tri_mesh.hpp
+++ b/zi_lib/zi/mesh/tri_mesh.hpp
@@ -239,7 +239,7 @@ public:
 
     uint32_t add_face(const uint32_t x, const uint32_t y, const uint32_t z)
     {
-
+        ZI_ASSERT(x != y && y != z && x != z);
         ZI_ASSERT(x < size_ && y < size_ && z < size_);
 
         const uint32_t max_face = faces_.push_back(face_type(x, y, z));

--- a/zi_lib/zi/mesh/tri_mesh.hpp
+++ b/zi_lib/zi/mesh/tri_mesh.hpp
@@ -121,58 +121,58 @@ struct trimesh_faces
 
 private:
     std::vector<face_slot> faces_;
-    std::vector<uint32_t> free_list_;
-    std::size_t size_;
+    std::vector<uint32_t>  free_list_;
+    std::size_t            size_;
+
 public:
-    trimesh_faces() {
-        size_ = 0;
-    }
+    trimesh_faces() { size_ = 0; }
 
-    void reserve(const std::size_t N) {
-        faces_.reserve(N);
-    }
+    void reserve(const std::size_t N) { faces_.reserve(N); }
 
-    bool alive(const uint32_t id) const {
-        if (id == 0 || id > faces_.size()) {
+    bool alive(const uint32_t id) const
+    {
+        if (id == 0 || id > faces_.size())
+        {
             return false;
         }
-        return faces_[id-1].alive;
+        return faces_[id - 1].alive;
     }
 
-    face_type get(const uint32_t id) const {
-        return faces_[id-1].face;
-    }
+    face_type get(const uint32_t id) const { return faces_[id - 1].face; }
 
-    std::size_t size() const  {
-        return size_;
-    }
+    std::size_t size() const { return size_; }
 
     std::size_t push_back(const face_type& face)
     {
         size_++;
-        if (free_list_.empty()) {
+        if (free_list_.empty())
+        {
             faces_.push_back(face);
             return faces_.size();
         }
-        else {
-            uint32_t id = free_list_.back();
-            faces_[id].face = face;
+        else
+        {
+            uint32_t id      = free_list_.back();
+            faces_[id].face  = face;
             faces_[id].alive = true;
-            return id+1;
+            return id + 1;
         }
     }
 
-    void clear() {
+    void clear()
+    {
         faces_.clear();
         free_list_.clear();
         size_ = 0;
     }
 
-    void erase(const uint32_t id) {
-        size_ -= static_cast<std::size_t>(faces_[id-1].alive);
-        faces_[id-1].alive = false;
-        auto it = std::find(free_list_.begin(), free_list_.end(), id-1);
-        if (it != free_list_.end()) {
+    void erase(const uint32_t id)
+    {
+        size_ -= static_cast<std::size_t>(faces_[id - 1].alive);
+        faces_[id - 1].alive = false;
+        auto it = std::find(free_list_.begin(), free_list_.end(), id - 1);
+        if (it != free_list_.end())
+        {
             free_list_.erase(it);
         }
     }
@@ -185,14 +185,14 @@ public:
                                      { return s.face; });
     }
 
-    auto enumerate() const {
-        return std::views::iota(std::size_t{0}, faces_.size())
-            | std::views::filter([this](std::size_t i) {
-                  return faces_[i].alive;
-              })
-            | std::views::transform([this](std::size_t i) {
-                  return std::pair{i+1, std::cref(faces_[i].face)};
-              });
+    auto enumerate() const
+    {
+        return std::views::iota(std::size_t{0}, faces_.size()) |
+               std::views::filter([this](std::size_t i)
+                                  { return faces_[i].alive; }) |
+               std::views::transform(
+                   [this](std::size_t i)
+                   { return std::pair{i + 1, std::cref(faces_[i].face)}; });
     }
 };
 
@@ -321,7 +321,6 @@ public:
         return *this;
     };
 
-
     void clear()
     {
         size_ = 0;
@@ -335,7 +334,7 @@ public:
         size_ = s;
         vertices_.resize(s);
         edges_.clear();
-        faces_.clear(); 
+        faces_.clear();
     }
 
     uint32_t add_face(const uint32_t x, const uint32_t y, const uint32_t z)
@@ -394,12 +393,12 @@ public:
 
         const uint32_t face_id = vertices_[id].face_;
 
-        if ( !faces_.alive( face_id ) )
+        if (!faces_.alive(face_id))
         {
             return 0;
         }
 
-        return faces_.get( face_id ).edge_from( id );
+        return faces_.get(face_id).edge_from(id);
     }
 
     uint32_t across_edge(const uint64_t eid) const

--- a/zi_lib/zi/mesh/tri_mesh.hpp
+++ b/zi_lib/zi/mesh/tri_mesh.hpp
@@ -30,7 +30,6 @@
 
 #    include <functional>
 #    include <iostream>
-#    include <ranges>
 #    include <stdexcept>
 #    include <vector>
 
@@ -437,40 +436,40 @@ public:
 
     std::size_t size() const { return size_; }
 
-    bool check_rep() const
-    {
+    // bool check_rep() const
+    // {
 
-        if (edges_.size() != faces_.size() * 3)
-        {
-            ZI_THROW("check_rep: extra edges present");
-        }
+    //     if (edges_.size() != faces_.size() * 3)
+    //     {
+    //         ZI_THROW("check_rep: extra edges present");
+    //     }
 
-        for (const auto& [face_id, face_ref] : faces_.enumerate())
-        {
-            const auto& face = face_ref.get();
+    //     for (const auto& [face_id, face_ref] : faces_.enumerate())
+    //     {
+    //         const auto& face = face_ref.get();
 
-            if (!(vertices_[face.v0()].valid() &&
-                  vertices_[face.v1()].valid() && vertices_[face.v2()].valid()))
-            {
-                ZI_THROW("check_rep: invalid vertex found");
-            }
+    //         if (!(vertices_[face.v0()].valid() &&
+    //               vertices_[face.v1()].valid() && vertices_[face.v2()].valid()))
+    //         {
+    //             ZI_THROW("check_rep: invalid vertex found");
+    //         }
 
-            if ((edges_.find(face.e0())->second).face() != face_id ||
-                (edges_.find(face.e1())->second).face() != face_id ||
-                (edges_.find(face.e2())->second).face() != face_id)
-            {
-                ZI_THROW("check_rep: edge doesn't link to the correct face");
-            }
+    //         if ((edges_.find(face.e0())->second).face() != face_id ||
+    //             (edges_.find(face.e1())->second).face() != face_id ||
+    //             (edges_.find(face.e2())->second).face() != face_id)
+    //         {
+    //             ZI_THROW("check_rep: edge doesn't link to the correct face");
+    //         }
 
-            if (!(edges_.count(face.e0()) && edges_.count(face.e1()) &&
-                  edges_.count(face.e2())))
-            {
-                ZI_THROW("check_rep: face missing an edge");
-            }
-        }
+    //         if (!(edges_.count(face.e0()) && edges_.count(face.e1()) &&
+    //               edges_.count(face.e2())))
+    //         {
+    //             ZI_THROW("check_rep: face missing an edge");
+    //         }
+    //     }
 
-        return true;
-    }
+    //     return true;
+    // }
 
     bool is_closed_surface() const
     {
@@ -505,7 +504,7 @@ public:
             }
         }
 
-        for (auto& face : faces_.iter())
+        for (auto face : faces_)
         {
             if (!(vertices_[face.v0()].valid() &&
                   vertices_[face.v1()].valid() && vertices_[face.v2()].valid()))
@@ -525,7 +524,7 @@ public:
 
     void print_faces() const
     {
-        for (auto& face : faces_.iter())
+        for (auto face : faces_)
         {
             std::cout << "f: " << face.v0() << ',' << face.v1() << ','
                       << face.v2() << '\n';
@@ -542,7 +541,7 @@ public:
     {
         r.resize(faces_.size());
         std::size_t i = 0;
-        for (auto& face : faces_.iter())
+        for (auto face : faces_)
         {
             r[i++] = T(face.v0(), face.v1(), face.v2());
         }

--- a/zi_lib/zi/mesh/tri_mesh.hpp
+++ b/zi_lib/zi/mesh/tri_mesh.hpp
@@ -416,7 +416,9 @@ public:
             const uint32_t  nv  = edg.vertex_;
 
             remove_face(edg.face_);
-            add_face(v2, v, nv);
+            if (v2 != v && nv != v) {
+                add_face(v2, v, nv);
+            }
             v = nv;
         }
 

--- a/zi_lib/zi/mesh/tri_mesh.hpp
+++ b/zi_lib/zi/mesh/tri_mesh.hpp
@@ -307,14 +307,9 @@ public:
         return *this;
     };
 
-    void clear(std::size_t s = 0)
-    {
-        if (s && (s != size_))
-        {
-            size_ = s;
-            vertices_.resize(s);
-        }
 
+    void clear()
+    {
         vertices_.clear();
         edges_.clear();
         faces_.clear();

--- a/zi_lib/zi/mesh/tri_mesh.hpp
+++ b/zi_lib/zi/mesh/tri_mesh.hpp
@@ -239,7 +239,7 @@ public:
 
     uint32_t add_face(const uint32_t x, const uint32_t y, const uint32_t z)
     {
-        ZI_ASSERT(x != y && y != z && x != z);
+
         ZI_ASSERT(x < size_ && y < size_ && z < size_);
 
         const uint32_t max_face = faces_.push_back(face_type(x, y, z));

--- a/zi_lib/zi/mesh/tri_mesh.hpp
+++ b/zi_lib/zi/mesh/tri_mesh.hpp
@@ -310,6 +310,7 @@ public:
 
     void clear()
     {
+        size_ = 0;
         vertices_.clear();
         edges_.clear();
         faces_.clear();

--- a/zi_lib/zi/mesh/tri_mesh.hpp
+++ b/zi_lib/zi/mesh/tri_mesh.hpp
@@ -121,9 +121,15 @@ struct trimesh_faces
 
 private:
     std::vector<face_slot> faces_;
-
+    std::size_t size_;
 public:
-    void reserve(const std::size_t N) { faces_.reserve(N); }
+    trimesh_faces() {
+        size_ = 0;
+    }
+
+    void reserve(const std::size_t N) {
+        faces_.reserve(N);
+    }
 
     bool alive(const uint32_t id) const
     {
@@ -131,22 +137,33 @@ public:
         {
             return false;
         }
-        return faces_[id].alive;
+        return faces_[id-1].alive;
     }
 
-    face_type get(const uint32_t id) const { return faces_[id].face; }
+    face_type get(const uint32_t id) const {
+        return faces_[id-1].face;
+    }
 
-    std::size_t size() const { return faces_.size(); }
+    std::size_t size() const  {
+        return size_;
+    }
 
     std::size_t push_back(const face_type& face)
     {
         faces_.push_back(face);
-        return faces_.size() - 1;
+        size_++;
+        return size_;
     }
 
-    void clear() { faces_.clear(); }
+    void clear() {
+        faces_.clear();
+        size_ = 0;
+    }
 
-    void erase(const uint32_t id) { faces_[id].alive = false; }
+    void erase(const uint32_t id) {
+        size_ -= faces_[id].alive;
+        faces_[id].alive = false;
+    }
 
     auto iter() const
     {
@@ -156,14 +173,14 @@ public:
                                      { return s.face; });
     }
 
-    auto enumerate() const
-    {
-        return std::views::iota(std::size_t{0}, faces_.size()) |
-               std::views::filter([this](std::size_t i)
-                                  { return faces_[i].alive; }) |
-               std::views::transform(
-                   [this](std::size_t i)
-                   { return std::pair{i, std::cref(faces_[i].face)}; });
+    auto enumerate() const {
+        return std::views::iota(std::size_t{0}, faces_.size())
+            | std::views::filter([this](std::size_t i) {
+                  return faces_[i].alive;
+              })
+            | std::views::transform([this](std::size_t i) {
+                  return std::pair{i+1, std::cref(faces_[i].face)};
+              });
     }
 };
 

--- a/zi_lib/zi/mesh/tri_mesh.hpp
+++ b/zi_lib/zi/mesh/tri_mesh.hpp
@@ -28,6 +28,7 @@
 #    include <zi/utility/for_each.hpp>
 #    include <zi/utility/robin_hood.hpp>
 
+#    include <ranges>
 #    include <functional>
 #    include <iostream>
 #    include <stdexcept>
@@ -96,6 +97,70 @@ struct tri_mesh_vertex
 
 } //  namespace detail
 
+struct face_slot {
+    typedef detail::tri_mesh_face_impl face_type;
+
+    face_type face;
+    bool alive;
+
+    face_slot() : alive(false) {}
+    face_slot(const face_type& face_) : face(face_), alive(true) {}
+};
+
+struct trimesh_faces {
+    typedef detail::tri_mesh_face_impl face_type;
+private:
+    std::vector<face_slot> faces_;
+public:
+    void reserve(const std::size_t N) {
+        faces_.reserve(N);
+    }
+
+    bool alive(const uint32_t id) const {
+        if (id >= faces_.size()) {
+            return false;
+        }
+        return faces_[id].alive;
+    }
+
+    face_type get(const uint32_t id) const {
+        return faces_[id].face;
+    }
+
+    std::size_t size() const  {
+        return faces_.size();
+    }
+
+    std::size_t push_back(const face_type& face) {
+        faces_.push_back(face);
+        return faces_.size() - 1;
+    }
+
+    void clear() {
+        faces_.clear();
+    }
+
+    void erase(const uint32_t id) {
+        faces_[id].alive = false;
+    }
+
+    auto iter() const {
+        return faces_
+            | std::views::filter([](const face_slot& s) { return s.alive; })
+            | std::views::transform([](const face_slot& s) -> const face_type& { return s.face; });
+    }
+
+    auto enumerate() const {
+        return std::views::iota(std::size_t{0}, faces_.size())
+            | std::views::filter([this](std::size_t i) {
+                  return faces_[i].alive;
+              })
+            | std::views::transform([this](std::size_t i) {
+                  return std::pair{i, std::cref(faces_[i].face)};
+              });
+    }
+};
+
 class tri_mesh //: non_copyable
 {
 public:
@@ -108,15 +173,13 @@ public:
     friend struct tri_mesh_edge;
 
 private:
-    std::size_t                                         size_;
-    std::vector<vertex_type>                            vertices_;
-    robin_hood::unordered_flat_map<uint64_t, edge_type> edges_;
-    unordered_map<uint32_t, face_type>                  faces_;
-    uint32_t                                            max_face_;
+    std::size_t                           size_    ;
+    std::vector  < vertex_type >          vertices_;
+    robin_hood::unordered_flat_map< uint64_t, edge_type >  edges_   ;
+    trimesh_faces                         faces_   ;
 
 public:
-    detail::tri_mesh_face_container faces;
-    detail::tri_mesh_edge_container edges;
+    detail::tri_mesh_edge_container       edges;
 
 private:
     void add_edge(uint32_t x, uint32_t y, uint32_t z, uint32_t f)
@@ -173,9 +236,15 @@ private:
     }
 
 public:
-    detail::tri_mesh_face_container& get_faces() { return faces; }
+    auto& get_faces()
+    {
+        return faces_;
+    }
 
-    const detail::tri_mesh_face_container& get_faces() const { return faces; }
+    const auto& get_faces() const
+    {
+        return faces_;
+    }
 
     std::vector<vertex_type>& vertices() { return vertices_; }
 
@@ -186,35 +255,32 @@ public:
     const detail::tri_mesh_edge_container& get_edges() const { return edges; }
 
     tri_mesh()
-        : size_(0)
-        , vertices_(0)
-        , edges_()
-        , faces_()
-        , max_face_(0)
-        , faces(faces_)
-        , edges(edges_)
+        : size_( 0 ),
+        vertices_( 0 ),
+        edges_(),
+        faces_(),
+        edges( edges_ )
     {
     }
 
-    explicit tri_mesh(std::size_t size)
-        : size_(size)
-        , vertices_(size)
-        , edges_()
-        , faces_()
-        , max_face_(0)
-        , faces(faces_)
-        , edges(edges_)
+    explicit tri_mesh( std::size_t size )
+        : size_( size ),
+          vertices_( size ),
+          edges_(),
+          faces_(),
+          edges( edges_ )
     {
+        faces_.reserve(size);
     }
 
-    tri_mesh(const tri_mesh& o)
-        : size_(o.size_)
-        , vertices_(o.vertices_)
-        , edges_(o.edges_)
-        , faces_(o.faces_)
-        , max_face_(o.max_face_)
-        , faces(faces_)
-        , edges(edges_) {};
+    tri_mesh( const tri_mesh& o )
+        : size_( o.size_ ),
+          vertices_( o.vertices_ ),
+          edges_( o.edges_ ),
+          faces_( o.faces_ ),
+          edges( edges_ )
+    {
+    };
 
     tri_mesh& operator=(const tri_mesh& o)
     {
@@ -222,10 +288,8 @@ public:
         vertices_ = o.vertices_;
         edges_    = o.edges_;
         faces_    = o.faces_;
-        max_face_ = o.max_face_;
 
-        faces = detail::tri_mesh_face_container(faces_);
-        edges = detail::tri_mesh_edge_container(edges_);
+        edges = detail::tri_mesh_edge_container( edges_ );
 
         return *this;
     };
@@ -241,7 +305,6 @@ public:
         vertices_.clear();
         edges_.clear();
         faces_.clear();
-        max_face_ = 0;
     }
 
     void resize(std::size_t s)
@@ -258,21 +321,20 @@ public:
 
         ZI_ASSERT(x < size_ && y < size_ && z < size_);
 
-        ++max_face_;
-        faces_.emplace(max_face_, face_type(x, y, z));
+        const uint32_t max_face = faces_.push_back(face_type( x, y, z ));
+        
+        add_edge( x, y, z, max_face );
+        add_edge( y, z, x, max_face );
+        add_edge( z, x, y, max_face );
 
-        add_edge(x, y, z, max_face_);
-        add_edge(y, z, x, max_face_);
-        add_edge(z, x, y, max_face_);
-
-        return max_face_;
+        return max_face;
     }
 
     void remove_face(const uint32_t id)
     {
-        ZI_ASSERT(faces_.count(id));
+        ZI_ASSERT( faces_.alive( id ) );
 
-        const face_type& f = faces_[id];
+        const face_type f = faces_.get(id);
 
         remove_edge(f.v0(), f.v1(), id);
         remove_edge(f.v1(), f.v2(), id);
@@ -308,14 +370,14 @@ public:
             return 0;
         }
 
-        auto it = faces_.find(vertices_[id].face_);
+        const uint32_t face_id = vertices_[ id ].face_;
 
-        if (it == faces_.end())
+        if ( faces_.alive( face_id ) )
         {
             return 0;
         }
 
-        return it->second.edge_from(id);
+        return faces_.get( face_id ).edge_from( face_id );
     }
 
     uint32_t across_edge(const uint64_t eid) const
@@ -461,25 +523,27 @@ public:
             ZI_THROW("check_rep: extra edges present");
         }
 
-        FOR_EACH(it, faces_)
+        for (const auto& [face_id, face_ref] : faces_.enumerate() )
         {
-            if (!(vertices_[it->second.v0()].valid() &&
-                  vertices_[it->second.v1()].valid() &&
-                  vertices_[it->second.v2()].valid()))
+            const auto& face = face_ref.get();
+
+            if ( !( vertices_[ face.v0() ].valid() &&
+                    vertices_[ face.v1() ].valid() &&
+                    vertices_[ face.v2() ].valid() ) )
             {
                 ZI_THROW("check_rep: invalid vertex found");
             }
 
-            if ((edges_.find(it->second.e0())->second).face() != it->first ||
-                (edges_.find(it->second.e1())->second).face() != it->first ||
-                (edges_.find(it->second.e2())->second).face() != it->first)
+            if ( ( edges_.find( face.e0() )->second ).face() != face_id ||
+                 ( edges_.find( face.e1() )->second ).face() != face_id ||
+                 ( edges_.find( face.e2() )->second ).face() != face_id )
             {
                 ZI_THROW("check_rep: edge doesn't link to the correct face");
             }
 
-            if (!(edges_.count(it->second.e0()) &&
-                  edges_.count(it->second.e1()) &&
-                  edges_.count(it->second.e2())))
+            if ( !( edges_.count( face.e0() ) &&
+                    edges_.count( face.e1() ) &&
+                    edges_.count( face.e2() ) ) )
             {
                 ZI_THROW("check_rep: face missing an edge");
             }
@@ -521,18 +585,18 @@ public:
             }
         }
 
-        FOR_EACH(it, faces_)
+        for ( auto& face : faces_.iter() )
         {
-            if (!(vertices_[it->second.v0()].valid() &&
-                  vertices_[it->second.v1()].valid() &&
-                  vertices_[it->second.v2()].valid()))
+            if ( !( vertices_[ face.v0() ].valid() &&
+                    vertices_[ face.v1() ].valid() &&
+                    vertices_[ face.v2() ].valid() ) )
             {
                 return false;
             }
 
-            if (!(edges_.count(it->second.e0()) &&
-                  edges_.count(it->second.e1()) &&
-                  edges_.count(it->second.e2())))
+            if ( !( edges_.count( face.e0() ) &&
+                    edges_.count( face.e1() ) &&
+                    edges_.count( face.e2() ) ) )
             {
                 return false;
             }
@@ -543,10 +607,12 @@ public:
 
     void print_faces() const
     {
-        FOR_EACH(it, faces_)
+        for ( auto& face : faces_.iter() )
         {
-            std::cout << "f: " << it->second.v0() << ',' << it->second.v1()
-                      << ',' << it->second.v2() << '\n';
+            std::cout << "f: "
+                      << face.v0() << ','
+                      << face.v1() << ','
+                      << face.v2() << '\n';
         }
     }
 
@@ -560,9 +626,9 @@ public:
     {
         r.resize(faces_.size());
         std::size_t i = 0;
-        FOR_EACH(it, faces_)
+        for ( auto& face : faces_.iter() )
         {
-            r[i++] = T(it->second.v0(), it->second.v1(), it->second.v2());
+            r[i++] = T(face.v0(), face.v1(), face.v2());
         }
         return r.size();
     }

--- a/zi_lib/zi/mesh/tri_mesh.hpp
+++ b/zi_lib/zi/mesh/tri_mesh.hpp
@@ -132,7 +132,7 @@ public:
     }
 
     bool alive(const uint32_t id) const {
-        if (id == 0 || id >= faces_.size()) {
+        if (id == 0 || id > faces_.size()) {
             return false;
         }
         return faces_[id-1].alive;

--- a/zi_lib/zi/mesh/tri_mesh.hpp
+++ b/zi_lib/zi/mesh/tri_mesh.hpp
@@ -159,7 +159,7 @@ public:
     }
 
     void erase(const uint32_t id) {
-        size_ -= faces_[id-1].alive;
+        size_ -= static_cast<std::size_t>(faces_[id-1].alive);
         faces_[id-1].alive = false;
     }
 

--- a/zi_lib/zi/mesh/tri_mesh.hpp
+++ b/zi_lib/zi/mesh/tri_mesh.hpp
@@ -385,7 +385,7 @@ public:
             return 0;
         }
 
-        return faces_.get(face_id).edge_from(face_id);
+        return faces_.get( face_id ).edge_from( id );
     }
 
     uint32_t across_edge(const uint64_t eid) const

--- a/zi_lib/zi/mesh/tri_mesh.hpp
+++ b/zi_lib/zi/mesh/tri_mesh.hpp
@@ -369,7 +369,7 @@ public:
 
         const uint32_t face_id = vertices_[id].face_;
 
-        if (faces_.alive(face_id))
+        if ( !faces_.alive( face_id ) )
         {
             return 0;
         }

--- a/zi_lib/zi/mesh/tri_mesh.hpp
+++ b/zi_lib/zi/mesh/tri_mesh.hpp
@@ -121,6 +121,7 @@ struct trimesh_faces
 
 private:
     std::vector<face_slot> faces_;
+    std::vector<uint32_t> free_list_;
     std::size_t size_;
 public:
     trimesh_faces() {
@@ -148,19 +149,32 @@ public:
 
     std::size_t push_back(const face_type& face)
     {
-        faces_.push_back(face);
         size_++;
-        return faces_.size();
+        if (free_list_.empty()) {
+            faces_.push_back(face);
+            return faces_.size();
+        }
+        else {
+            uint32_t id = free_list_.back();
+            faces_[id].face = face;
+            faces_[id].alive = true;
+            return id+1;
+        }
     }
 
     void clear() {
         faces_.clear();
+        free_list_.clear();
         size_ = 0;
     }
 
     void erase(const uint32_t id) {
         size_ -= static_cast<std::size_t>(faces_[id-1].alive);
         faces_[id-1].alive = false;
+        auto it = std::find(free_list_.begin(), free_list_.end(), id-1);
+        if (it != free_list_.end()) {
+            free_list_.erase(it);
+        }
     }
 
     auto iter() const

--- a/zi_lib/zi/mesh/tri_stripper.hpp
+++ b/zi_lib/zi/mesh/tri_stripper.hpp
@@ -309,11 +309,11 @@ public:
         unordered_map<uint64_t, uint32_t>::const_iterator eit;
 
         uint32_t idx = 0;
-        FOR_EACH(it, mesh.faces)
+        for( auto& face : mesh.get_faces().iter() )
         {
-            const uint32_t& v1 = it->v0();
-            const uint32_t& v2 = it->v1();
-            const uint32_t& v3 = it->v2();
+            const uint32_t& v1 = face.v0();
+            const uint32_t& v2 = face.v1();
+            const uint32_t& v3 = face.v2();
 
             const uint32_t ioff = idx << 2;
 

--- a/zi_lib/zi/mesh/tri_stripper.hpp
+++ b/zi_lib/zi/mesh/tri_stripper.hpp
@@ -309,7 +309,7 @@ public:
         unordered_map<uint64_t, uint32_t>::const_iterator eit;
 
         uint32_t idx = 0;
-        for (auto& face : mesh.get_faces().iter())
+        for (auto face : mesh.get_faces())
         {
             const uint32_t& v1 = face.v0();
             const uint32_t& v2 = face.v1();

--- a/zi_lib/zi/mesh/tri_stripper.hpp
+++ b/zi_lib/zi/mesh/tri_stripper.hpp
@@ -309,7 +309,7 @@ public:
         unordered_map<uint64_t, uint32_t>::const_iterator eit;
 
         uint32_t idx = 0;
-        for( auto& face : mesh.get_faces().iter() )
+        for (auto& face : mesh.get_faces().iter())
         {
             const uint32_t& v1 = face.v0();
             const uint32_t& v2 = face.v1();

--- a/zmesh/cMesher.hpp
+++ b/zmesh/cMesher.hpp
@@ -258,6 +258,31 @@ class CMesher {
     return obj;
   }
 
+  auto simplify(
+    const zmesh::utility::MeshObject& mesh,
+    bool generate_normals,
+    int simplification_factor,
+    float max_simplification_error,
+    float min_simplification_error,
+
+    // This is to support the old broken version
+    // w/ backwards compatibility
+    bool transpose = true
+  ) {
+    std::deque< zi::vl::vec< PositionType, 3> >& triangles;
+    for (int i = 0; i < mesh.faces.size(); i++) {
+        triangles.push_back(mesh.points[mesh.faces[i]]);
+    }
+
+    return simplify(
+      triangles, 
+      generate_normals,
+      simplification_factor, 
+      max_simplification_error, 
+      min_simplification_error
+    );
+  }
+
   zmesh::utility::MeshObject simplify_points(
     const uint64_t* points,
     const size_t Nv,

--- a/zmesh/cMesher.hpp
+++ b/zmesh/cMesher.hpp
@@ -270,8 +270,13 @@ class CMesher {
     bool transpose = true
   ) {
     std::deque< zi::vl::vec< PositionType, 3> > triangles;
-    for (int i = 0; i < mesh.faces.size(); i++) {
-        triangles.push_back(mesh.points[mesh.faces[i]]);
+    for (int i = 0; i < mesh.faces.size(); i += 3) {
+      zi::vl::vec< PositionType, 3 > vec(
+        mesh.points[mesh.faces[i]],
+        mesh.points[mesh.faces[i+1]],
+        mesh.points[mesh.faces[i+2]]
+      );
+      triangles.push_back(vec);
     }
 
     return simplify(

--- a/zmesh/cMesher.hpp
+++ b/zmesh/cMesher.hpp
@@ -269,7 +269,7 @@ class CMesher {
     // w/ backwards compatibility
     bool transpose = true
   ) {
-    std::deque< zi::vl::vec< PositionType, 3> >& triangles;
+    std::deque< zi::vl::vec< PositionType, 3> > triangles;
     for (int i = 0; i < mesh.faces.size(); i++) {
         triangles.push_back(mesh.points[mesh.faces[i]]);
     }

--- a/zmesh/cMesher.hpp
+++ b/zmesh/cMesher.hpp
@@ -270,13 +270,26 @@ class CMesher {
     bool transpose = true
   ) {
     std::deque< zi::vl::vec< PositionType, 3> > triangles;
-    for (int i = 0; i < mesh.faces.size(); i += 3) {
-      zi::vl::vec< PositionType, 3 > vec(
-        mesh.points[mesh.faces[i]],
-        mesh.points[mesh.faces[i+1]],
-        mesh.points[mesh.faces[i+2]]
-      );
-      triangles.push_back(vec);
+
+    if (transpose) {
+      for (int i = 0; i < mesh.faces.size(); i += 3) {
+        zi::vl::vec< PositionType, 3 > vec(
+          mesh.points[mesh.faces[i+2]],
+          mesh.points[mesh.faces[i+1]],
+          mesh.points[mesh.faces[i+0]]
+        );
+        triangles.push_back(vec);
+      }
+    }
+    else {
+      for (int i = 0; i < mesh.faces.size(); i += 3) {
+        zi::vl::vec< PositionType, 3 > vec(
+          mesh.points[mesh.faces[i+0]],
+          mesh.points[mesh.faces[i+1]],
+          mesh.points[mesh.faces[i+2]]
+        );
+        triangles.push_back(vec);
+      }
     }
 
     return simplify(


### PR DESCRIPTION
Instead of using a map, use a vector with tombstones and a reuse list.

Something like an 8% improvement. New and old have similar memory profiles.
<img width="849" height="498" alt="image" src="https://github.com/user-attachments/assets/e723bb1b-62ce-4520-b70f-5b20c7795679" />
