### PR TITLE
perf: faster equality check for marching cubes

### DIFF
--- a/zi_lib/zi/mesh/marching_cubes.hpp
+++ b/zi_lib/zi/mesh/marching_cubes.hpp
@@ -448,25 +448,49 @@ private:
                         data[ind + strides[5]],                     
                         data[ind + strides[6]]};                    
 
-                    if (!skip_check) {
-                        bool front_equal = (
-                            (labels[1] == labels[2])
-                            && (labels[1] == labels[5])
-                            && (labels[1] == labels[6])
-                        );
-                        bool back_equal = (
-                            (labels[0] == labels[3])
-                            && (labels[0] == labels[4])
-                            && (labels[0] == labels[7])
-                        );
-                        skip_check = !front_equal;
-                        if (back_equal && front_equal && labels[0] == labels[1])
-                        {
-                            return;
+                    if constexpr (std::is_same_v<Tag, fortran_order_tag>) {
+                        if (!skip_check) {
+                            bool front_equal = (
+                                (labels[1] == labels[2])
+                                && (labels[1] == labels[5])
+                                && (labels[1] == labels[6])
+                            );
+                            bool back_equal = (
+                                (labels[0] == labels[3])
+                                && (labels[0] == labels[4])
+                                && (labels[0] == labels[7])
+                            );
+                            skip_check = !front_equal;
+                            if (back_equal && front_equal && labels[0] == labels[1])
+                            {
+                                return;
+                            }
+                        }
+                        else {
+                            skip_check = false;
                         }
                     }
                     else {
-                        skip_check = false;
+                        if (!skip_check) {
+                            bool front_equal = (
+                                (labels[2] == labels[3])
+                                && (labels[2] == labels[6])
+                                && (labels[2] == labels[7])
+                            );
+                            bool back_equal = (
+                                (labels[0] == labels[1])
+                                && (labels[0] == labels[4])
+                                && (labels[0] == labels[5])
+                            );
+                            skip_check = !front_equal;
+                            if (back_equal && front_equal && labels[0] == labels[2])
+                            {
+                                return;
+                            }
+                        }
+                        else {
+                            skip_check = false;
+                        }
                     }
 
                     uint8_t accumulate = 0;

--- a/zi_lib/zi/mesh/marching_cubes.hpp
+++ b/zi_lib/zi/mesh/marching_cubes.hpp
@@ -455,13 +455,13 @@ private:
                                 && (labels[1] == labels[5])
                                 && (labels[1] == labels[6])
                             );
-                            bool back_equal = (
+                            bool front_and_back_equal = front_equal && (
                                 (labels[0] == labels[3])
                                 && (labels[0] == labels[4])
                                 && (labels[0] == labels[7])
                             );
                             skip_check = !front_equal;
-                            if (back_equal && front_equal && labels[0] == labels[1])
+                            if (front_and_back_equal && labels[0] == labels[1])
                             {
                                 return;
                             }
@@ -477,13 +477,13 @@ private:
                                 && (labels[2] == labels[6])
                                 && (labels[2] == labels[7])
                             );
-                            bool back_equal = (
+                            bool front_and_back_equal = front_equal && (
                                 (labels[0] == labels[1])
                                 && (labels[0] == labels[4])
                                 && (labels[0] == labels[5])
                             );
                             skip_check = !front_equal;
-                            if (back_equal && front_equal && labels[0] == labels[2])
+                            if (front_and_back_equal && labels[0] == labels[2])
                             {
                                 return;
                             }

--- a/zi_lib/zi/mesh/marching_cubes.hpp
+++ b/zi_lib/zi/mesh/marching_cubes.hpp
@@ -99,10 +99,6 @@ private:
     marching_cubes(marching_cubes const&)            = delete;
     marching_cubes& operator=(marching_cubes const&) = delete;
 
-    // static std::size_t const tri_table_end = 0xffffffff;
-    // static std::size_t const edge_table[256];
-    // static std::size_t const tri_table[256][16];
-
     using mask_traits = mc_masks<PositionType>;
 
 public:

--- a/zi_lib/zi/mesh/marching_cubes.hpp
+++ b/zi_lib/zi/mesh/marching_cubes.hpp
@@ -448,6 +448,9 @@ private:
                         data[ind + strides[5]],                     
                         data[ind + strides[6]]};                    
 
+                    // check for solid color 2x2x2 region taking advantage
+                    // of the sliding window to skip a check on the next
+                    // iteration if the front of the block is not-solid color
                     if constexpr (std::is_same_v<Tag, fortran_order_tag>) {
                         if (!skip_check) {
                             bool front_equal = (

--- a/zi_lib/zi/mesh/marching_cubes.hpp
+++ b/zi_lib/zi/mesh/marching_cubes.hpp
@@ -430,24 +430,43 @@ private:
         }
         else
         {
+
+            bool skip_check = false;
+
             mc_nested_loops(
                 sx, sy, sz,
                 [&](std::size_t x, std::size_t y, std::size_t z,
                     std::size_t ind)
                 {
                     std::array<LabelType, 8> const labels = {
-                        data[ind],
-                        data[ind + strides[0]],
-                        data[ind + strides[1]],
-                        data[ind + strides[2]],
-                        data[ind + strides[3]],
-                        data[ind + strides[4]],
-                        data[ind + strides[5]],
-                        data[ind + strides[6]]};
+                        data[ind],                  
+                        data[ind + strides[0]],                     
+                        data[ind + strides[1]],                     
+                        data[ind + strides[2]],                     
+                        data[ind + strides[3]],                     
+                        data[ind + strides[4]],                     
+                        data[ind + strides[5]],                     
+                        data[ind + strides[6]]};                    
 
-                    if (all_equal_branchless(labels))
-                    {
-                        return;
+                    if (!skip_check) {
+                        bool front_equal = (
+                            (labels[1] == labels[2])
+                            && (labels[1] == labels[5])
+                            && (labels[1] == labels[6])
+                        );
+                        bool back_equal = (
+                            (labels[0] == labels[3])
+                            && (labels[0] == labels[4])
+                            && (labels[0] == labels[7])
+                        );
+                        skip_check = !front_equal;
+                        if (back_equal && front_equal && labels[0] == labels[1])
+                        {
+                            return;
+                        }
+                    }
+                    else {
+                        skip_check = false;
                     }
 
                     uint8_t accumulate = 0;


### PR DESCRIPTION
This is kind of ugly, but it has an interesting principle. It exploits the sliding window property to skip some equality checks.

When the front of the 2x2x2 cube is not solid-color, when it slides backwards to the rear, the solid color check will certainly fail the next iteration.

This improves performance about 5%. 
