### PR TITLE
refactor: remove preserve_order parameter

### DIFF
--- a/automated_test.py
+++ b/automated_test.py
@@ -22,13 +22,12 @@ def fanc_label():
 @pytest.mark.parametrize("dtype", DTYPE)
 @pytest.mark.parametrize("close", [ False, True ])
 @pytest.mark.parametrize("order", [ 'C', 'F' ])
-@pytest.mark.parametrize("preserve_order", [ True, False ])
-def test_executes_legacy(dtype, close, order, preserve_order):
+def test_executes_legacy(dtype, close, order):
   labels = np.zeros( (11,17,19), dtype=dtype, order=order)
   labels[1:-1, 1:-1, 1:-1] = 1
 
   mesher = zmesh.Mesher( (4,4,40) )
-  mesher.mesh(labels, close=close, preserve_order=preserve_order)
+  mesher.mesh(labels, close=close)
 
   mesh = mesher.get_mesh(1, normals=False)
   assert len(mesh.vertices) > 0
@@ -44,13 +43,12 @@ def test_executes_legacy(dtype, close, order, preserve_order):
 @pytest.mark.parametrize("dtype", DTYPE)
 @pytest.mark.parametrize("close", [ False, True ])
 @pytest.mark.parametrize("order", [ 'C', 'F' ])
-@pytest.mark.parametrize("preserve_order", [ True, False ])
-def test_executes(dtype, close, order, preserve_order):
+def test_executes(dtype, close, order):
   labels = np.zeros( (11,17,19), dtype=dtype, order=order)
   labels[1:-1, 1:-1, 1:-1] = 1
 
   mesher = zmesh.Mesher( (4,4,40) )
-  mesher.mesh(labels, close=close, preserve_order=preserve_order)
+  mesher.mesh(labels, close=close)
 
   mesh = mesher.get(1, normals=False)
   assert len(mesh.vertices) > 0
@@ -64,13 +62,12 @@ def test_executes(dtype, close, order, preserve_order):
 
 @pytest.mark.parametrize("dtype", DTYPE)
 @pytest.mark.parametrize("order", [ 'C', 'F' ])
-@pytest.mark.parametrize("preserve_order", [ True, False ])
-def test_simplify(dtype, order, preserve_order):
+def test_simplify(dtype, order):
   labels = np.zeros( (11,17,19), dtype=dtype, order=order)
   labels[1:-1, 1:-1, 1:-1] = 1
 
   mesher = zmesh.Mesher( (4,4,40) )
-  mesher.mesh(labels, preserve_order=preserve_order)
+  mesher.mesh(labels)
 
   mesh = mesher.get_mesh(1, normals=False)
   Nv = len(mesh.vertices)
@@ -109,13 +106,12 @@ def test_simplify(dtype, order, preserve_order):
     pass
 
 @pytest.mark.parametrize("dtype", DTYPE)
-@pytest.mark.parametrize("preserve_order", [ True, False ])
-def test_precomputed_legacy(dtype, preserve_order):
+def test_precomputed_legacy(dtype):
   labels = np.zeros( (11,17,19), dtype=dtype)
   labels[1:-1, 1:-1, 1:-1] = 1
 
   mesher = zmesh.Mesher( (4,4,40) )
-  mesher.mesh(labels, preserve_order=preserve_order)
+  mesher.mesh(labels)
   mesh = mesher.get_mesh(1, normals=False)
 
   precomputed_mesh = mesh.to_precomputed()
@@ -197,18 +193,17 @@ def test_C_F_meshes_same_legacy(connectomics_labels):
     assert np.isclose(c_mesh.vertices.mean(), f_mesh.vertices.mean())
 
 @pytest.mark.parametrize("transpose", [True,False])
-@pytest.mark.parametrize("preserve_order", [ True, False ])
-def test_fanc_bug(fanc_label, transpose, preserve_order):
+def test_fanc_bug(fanc_label, transpose):
   if transpose:
     fanc_label = fanc_label.T
   fdata = np.asfortranarray(fanc_label)
   cdata = np.ascontiguousarray(fanc_label)
 
   f_mesher = zmesh.Mesher((1,1,1))
-  f_mesher.mesh(fdata ,preserve_order=preserve_order)
+  f_mesher.mesh(fdata)
 
   c_mesher = zmesh.Mesher((1,1,1))
-  c_mesher.mesh(cdata, preserve_order=preserve_order)
+  c_mesher.mesh(cdata)
 
   assert c_mesher.ids() == f_mesher.ids()
 
@@ -737,11 +732,5 @@ def test_crackle_marching_cubes(connectomics_labels):
   for label, mesh in results.items():
     crackle_mesh = results2[label]
     assert mesh == crackle_mesh
-
-
-
-
-
-
 
 

--- a/templates/mesherclass.j2
+++ b/templates/mesherclass.j2
@@ -7,12 +7,11 @@ cdef class Mesher{{ position_type }}{{ '%02d' % label_type }}:
   def __dealloc__(self):
     del self.ptr
 
-  def mesh(self, data, preserve_order:bool):
+  def mesh(self, data):
     cdef cnp.ndarray[uint{{label_type}}_t, ndim=1] flat_data = reshape(data, (data.size,)).view(np.uint{{ label_type }})
     self.ptr.mesh(
       &flat_data[0],
       data.shape[0], data.shape[1], data.shape[2],
-      preserve_order,
       data.flags.c_contiguous
     )
 

--- a/zi_lib/zi/mesh/marching_cubes.hpp
+++ b/zi_lib/zi/mesh/marching_cubes.hpp
@@ -292,7 +292,7 @@ private:
     ZMESH_FLATTEN // e.g. [[gnu::flatten]] gets add_face lambda to inline properly, defined in builtins.hpp
     void marche(const LabelType* data, std::size_t const sx,
                 std::size_t const sy, std::size_t const sz,
-                const bool preserve_order, Tag const& order_tag)
+                Tag const& order_tag)
     {
         meshes_.reserve(sx * sy);
 
@@ -343,193 +343,105 @@ private:
             }
         };
 
-        if (preserve_order)
-        {
-            mc_nested_loops(
-                sx, sy, sz,
-                [&](std::size_t x, std::size_t y, std::size_t z,
-                    std::size_t ind)
-                {
-                    std::array<LabelType, 8> const labels = {
-                        data[ind],
-                        data[ind + strides[0]],
-                        data[ind + strides[1]],
-                        data[ind + strides[2]],
-                        data[ind + strides[3]],
-                        data[ind + strides[4]],
-                        data[ind + strides[5]],
-                        data[ind + strides[6]]};
+        bool skip_check = false;
 
-                    if (all_equal_branchless(labels))
-                    {
-                        return;
-                    }
+        mc_nested_loops(
+            sx, sy, sz,
+            [&](std::size_t x, std::size_t y, std::size_t z,
+                std::size_t ind)
+            {
+                std::array<LabelType, 8> const labels = {
+                    data[ind],                  
+                    data[ind + strides[0]],                     
+                    data[ind + strides[1]],                     
+                    data[ind + strides[2]],                     
+                    data[ind + strides[3]],                     
+                    data[ind + strides[4]],                     
+                    data[ind + strides[5]],                     
+                    data[ind + strides[6]]};                    
 
-                    // Instead of using std::unordered_set or similar
-                    // to get unique labels, use a high efficiency sort,
-                    // a "network sort", for a fixed size labels and then
-                    // iterate from high to low values and skip repeats.
-                    // This Saves almost 40% of the march time. We make an
-                    // array copy before sorting to preserve the structure
-                    // in labels. std::unordered_set uses a hash with closed
-                    // addressing + chaining which is inefficient for our
-                    // case.
-                    std::array<LabelType, 8> ulabels = labels;
-                    zi::mesh::sort_8(ulabels);
-
-                    // i=7
-                    uint8_t accumulate = 0;
-                    uint8_t c;
-
-                    LabelType label = ulabels[7];
-                    if (label == 0)
-                    {
-                        return;
-                    }
-
-                    c = 0;
-                    for (int n = 0; n < 8; n++)
-                    {
-                        c |= (uint8_t)(labels[n] != label) << n;
-                    }
-                    accumulate |= (uint8_t)~c;
-                    add_face(x, y, z, label, c);
-
-                    for (int i = 6; i >= 0 && accumulate != 0xff; i--)
-                    {
-                        label = ulabels[i];
-                        if (label == 0)
+                // check for solid color 2x2x2 region taking advantage
+                // of the sliding window to skip a check on the next
+                // iteration if the front of the block is not-solid color
+                if constexpr (std::is_same_v<Tag, fortran_order_tag>) {
+                    if (!skip_check) {
+                        bool front_equal = (
+                            (labels[1] == labels[2])
+                            && (labels[1] == labels[5])
+                            && (labels[1] == labels[6])
+                        );
+                        bool front_and_back_equal = front_equal && (
+                            (labels[0] == labels[3])
+                            && (labels[0] == labels[4])
+                            && (labels[0] == labels[7])
+                        );
+                        skip_check = !front_equal;
+                        if (front_and_back_equal && labels[0] == labels[1])
                         {
-                            break;
-                        }
-                        else if (ulabels[i + 1] == label)
-                        {
-                            continue;
-                        }
-
-                        if (label == ulabels[0])
-                        {
-                            c = accumulate;
-                            add_face(x, y, z, label, c);
-                            break;
-                        }
-                        else
-                        {
-                            c = 0;
-                            for (int n = 0; n < 8; n++)
-                            {
-                                c |= (uint8_t)(labels[n] != label) << n;
-                            }
-                            accumulate |= (uint8_t)~c;
-                            add_face(x, y, z, label, c);
-                        }
-                    }
-                },
-                order_tag);
-        }
-        else
-        {
-
-            bool skip_check = false;
-
-            mc_nested_loops(
-                sx, sy, sz,
-                [&](std::size_t x, std::size_t y, std::size_t z,
-                    std::size_t ind)
-                {
-                    std::array<LabelType, 8> const labels = {
-                        data[ind],                  
-                        data[ind + strides[0]],                     
-                        data[ind + strides[1]],                     
-                        data[ind + strides[2]],                     
-                        data[ind + strides[3]],                     
-                        data[ind + strides[4]],                     
-                        data[ind + strides[5]],                     
-                        data[ind + strides[6]]};                    
-
-                    // check for solid color 2x2x2 region taking advantage
-                    // of the sliding window to skip a check on the next
-                    // iteration if the front of the block is not-solid color
-                    if constexpr (std::is_same_v<Tag, fortran_order_tag>) {
-                        if (!skip_check) {
-                            bool front_equal = (
-                                (labels[1] == labels[2])
-                                && (labels[1] == labels[5])
-                                && (labels[1] == labels[6])
-                            );
-                            bool front_and_back_equal = front_equal && (
-                                (labels[0] == labels[3])
-                                && (labels[0] == labels[4])
-                                && (labels[0] == labels[7])
-                            );
-                            skip_check = !front_equal;
-                            if (front_and_back_equal && labels[0] == labels[1])
-                            {
-                                return;
-                            }
-                        }
-                        else {
-                            skip_check = false;
+                            return;
                         }
                     }
                     else {
-                        if (!skip_check) {
-                            bool front_equal = (
-                                (labels[2] == labels[3])
-                                && (labels[2] == labels[6])
-                                && (labels[2] == labels[7])
-                            );
-                            bool front_and_back_equal = front_equal && (
-                                (labels[0] == labels[1])
-                                && (labels[0] == labels[4])
-                                && (labels[0] == labels[5])
-                            );
-                            skip_check = !front_equal;
-                            if (front_and_back_equal && labels[0] == labels[2])
-                            {
-                                return;
-                            }
-                        }
-                        else {
-                            skip_check = false;
+                        skip_check = false;
+                    }
+                }
+                else {
+                    if (!skip_check) {
+                        bool front_equal = (
+                            (labels[2] == labels[3])
+                            && (labels[2] == labels[6])
+                            && (labels[2] == labels[7])
+                        );
+                        bool front_and_back_equal = front_equal && (
+                            (labels[0] == labels[1])
+                            && (labels[0] == labels[4])
+                            && (labels[0] == labels[5])
+                        );
+                        skip_check = !front_equal;
+                        if (front_and_back_equal && labels[0] == labels[2])
+                        {
+                            return;
                         }
                     }
+                    else {
+                        skip_check = false;
+                    }
+                }
 
-                    uint8_t accumulate = 0;
-                    uint8_t c          = 0;
+                uint8_t accumulate = 0;
+                uint8_t c          = 0;
 
-                    for (int i = 0; i < 8 && accumulate != 0xff; i++)
+                for (int i = 0; i < 8 && accumulate != 0xff; i++)
+                {
+                    int start = zmesh_ctz((uint8_t)~accumulate);
+                    int end = 8 - ((zmesh_clz((uint8_t)~accumulate)) - 24);
+
+                    const LabelType label = labels[start];
+
+                    c = 0;
+                    if (end == 8)
                     {
-                        int start = zmesh_ctz((uint8_t)~accumulate);
-                        int end = 8 - ((zmesh_clz((uint8_t)~accumulate)) - 24);
-
-                        const LabelType label = labels[start];
-
-                        c = 0;
-                        if (end == 8)
+                        for (int n = start; n < 8; n++)
                         {
-                            for (int n = start; n < 8; n++)
-                            {
-                                c |= (uint8_t)(labels[n] == label) << n;
-                            }
-                        }
-                        else
-                        {
-                            for (int n = start; n < end; n++)
-                            {
-                                c |= (uint8_t)(labels[n] == label) << n;
-                            }
-                        }
-                        accumulate |= (uint8_t)c;
-
-                        if (label != 0)
-                        {
-                            add_face(x, y, z, label, (uint8_t)~c);
+                            c |= (uint8_t)(labels[n] == label) << n;
                         }
                     }
-                },
-                order_tag);
-        }
+                    else
+                    {
+                        for (int n = start; n < end; n++)
+                        {
+                            c |= (uint8_t)(labels[n] == label) << n;
+                        }
+                    }
+                    accumulate |= (uint8_t)c;
+
+                    if (label != 0)
+                    {
+                        add_face(x, y, z, label, (uint8_t)~c);
+                    }
+                }
+            },
+            order_tag);
     }
 
 public:
@@ -731,15 +643,15 @@ public:
 
     void marche(const LabelType* data, std::size_t const sx,
                 std::size_t const sy, std::size_t const sz,
-                const bool preserve_order = true, const bool c_order = true)
+                const bool c_order = true)
     {
         if (c_order)
         {
-            marche(data, sx, sy, sz, preserve_order, c_order_tag());
+            marche(data, sx, sy, sz, c_order_tag());
         }
         else
         {
-            marche(data, sx, sy, sz, preserve_order, fortran_order_tag());
+            marche(data, sx, sy, sz, fortran_order_tag());
         }
     }
 

--- a/zmesh/_zmesh.pyx
+++ b/zmesh/_zmesh.pyx
@@ -79,11 +79,6 @@ cdef extern from "cMesher.hpp" namespace "zmesh":
       unsigned int sx, 
       unsigned int sy, 
       unsigned int sz, 
-      # for backwards compatibility 
-      # preserve final vertex/face order
-      # set false for additional performance
-      # but possibly a different mesh binary
-      bool preserve_order, 
       bool c_order # this is the input array order, C or F
     ) nogil
     void mesh_crackle(
@@ -510,7 +505,7 @@ class Mesher:
         data = tmp
         del tmp
 
-      return self._mesher.mesh(data, preserve_order=preserve_order)
+      return self._mesher.mesh(data)
 
   @cython.binding(True)
   def ids(self):
@@ -750,12 +745,11 @@ cdef class Mesher3208:
   def __dealloc__(self):
     del self.ptr
 
-  def mesh(self, data, preserve_order:bool):
+  def mesh(self, data):
     cdef cnp.ndarray[uint8_t, ndim=1] flat_data = reshape(data, (data.size,)).view(np.uint8)
     self.ptr.mesh(
       &flat_data[0],
       data.shape[0], data.shape[1], data.shape[2],
-      preserve_order,
       data.flags.c_contiguous
     )
 
@@ -788,12 +782,11 @@ cdef class Mesher3216:
   def __dealloc__(self):
     del self.ptr
 
-  def mesh(self, data, preserve_order:bool):
+  def mesh(self, data):
     cdef cnp.ndarray[uint16_t, ndim=1] flat_data = reshape(data, (data.size,)).view(np.uint16)
     self.ptr.mesh(
       &flat_data[0],
       data.shape[0], data.shape[1], data.shape[2],
-      preserve_order,
       data.flags.c_contiguous
     )
 
@@ -826,12 +819,11 @@ cdef class Mesher3232:
   def __dealloc__(self):
     del self.ptr
 
-  def mesh(self, data, preserve_order:bool):
+  def mesh(self, data):
     cdef cnp.ndarray[uint32_t, ndim=1] flat_data = reshape(data, (data.size,)).view(np.uint32)
     self.ptr.mesh(
       &flat_data[0],
       data.shape[0], data.shape[1], data.shape[2],
-      preserve_order,
       data.flags.c_contiguous
     )
 
@@ -864,12 +856,11 @@ cdef class Mesher3264:
   def __dealloc__(self):
     del self.ptr
 
-  def mesh(self, data, preserve_order:bool):
+  def mesh(self, data):
     cdef cnp.ndarray[uint64_t, ndim=1] flat_data = reshape(data, (data.size,)).view(np.uint64)
     self.ptr.mesh(
       &flat_data[0],
       data.shape[0], data.shape[1], data.shape[2],
-      preserve_order,
       data.flags.c_contiguous
     )
 
@@ -902,12 +893,11 @@ cdef class Mesher6408:
   def __dealloc__(self):
     del self.ptr
 
-  def mesh(self, data, preserve_order:bool):
+  def mesh(self, data):
     cdef cnp.ndarray[uint8_t, ndim=1] flat_data = reshape(data, (data.size,)).view(np.uint8)
     self.ptr.mesh(
       &flat_data[0],
       data.shape[0], data.shape[1], data.shape[2],
-      preserve_order,
       data.flags.c_contiguous
     )
 
@@ -940,12 +930,11 @@ cdef class Mesher6416:
   def __dealloc__(self):
     del self.ptr
 
-  def mesh(self, data, preserve_order:bool):
+  def mesh(self, data):
     cdef cnp.ndarray[uint16_t, ndim=1] flat_data = reshape(data, (data.size,)).view(np.uint16)
     self.ptr.mesh(
       &flat_data[0],
       data.shape[0], data.shape[1], data.shape[2],
-      preserve_order,
       data.flags.c_contiguous
     )
 
@@ -978,12 +967,11 @@ cdef class Mesher6432:
   def __dealloc__(self):
     del self.ptr
 
-  def mesh(self, data, preserve_order:bool):
+  def mesh(self, data):
     cdef cnp.ndarray[uint32_t, ndim=1] flat_data = reshape(data, (data.size,)).view(np.uint32)
     self.ptr.mesh(
       &flat_data[0],
       data.shape[0], data.shape[1], data.shape[2],
-      preserve_order,
       data.flags.c_contiguous
     )
 
@@ -1016,12 +1004,11 @@ cdef class Mesher6464:
   def __dealloc__(self):
     del self.ptr
 
-  def mesh(self, data, preserve_order:bool):
+  def mesh(self, data):
     cdef cnp.ndarray[uint64_t, ndim=1] flat_data = reshape(data, (data.size,)).view(np.uint64)
     self.ptr.mesh(
       &flat_data[0],
       data.shape[0], data.shape[1], data.shape[2],
-      preserve_order,
       data.flags.c_contiguous
     )
 

--- a/zmesh/cMesher.hpp
+++ b/zmesh/cMesher.hpp
@@ -29,11 +29,10 @@ class CMesher {
   void mesh(
     const LabelType* data, 
     const size_t sx, const size_t sy, const size_t sz,
-    const bool preserve_order = true,
     const bool c_order = true
   ) {
     // Run global marching cubes, a mesh is generated for each segment ID group
-    marchingcubes_.marche(data, sx, sy, sz, preserve_order, c_order);
+    marchingcubes_.marche(data, sx, sy, sz, c_order);
   }
 
   void mesh_crackle(


### PR DESCRIPTION
I was mistaken that it was needed in the first place. Marching cubes does iterate over labels in a different order but then it does a hashmap access for each one. The order doesn't matter.

Removing this parameter will improve meshing speed for everyone.